### PR TITLE
Added thinking to conversations (supported by Claude and VS Code)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,12 @@ Browse the full history of your Copilot sessions in a searchable, filterable lis
 
 **Conversation view:**
 - Chat-style layout — your prompts on the right, Copilot responses on the left
+- **Agent thinking** — collapsible reasoning blocks shown inline between messages (click "💭 View thinking" to expand)
 - Tool calls made during the session
 - Errors that occurred
 - Session plans (if created)
+
+> **Thinking support by source:** Claude Code and VS Code Copilot Chat sessions surface thinking blocks when the model was run with extended thinking enabled. Copilot CLI sessions do not include thinking — the CLI processes reasoning internally and does not persist it to disk.
 
 ![copilot-lens sessions list](https://raw.githubusercontent.com/pavanvamsi3/copilot-lens/main/assets/copilot-lens-sessions-list.png)
 
@@ -134,6 +137,7 @@ VS Code Insiders is also supported. Sessions with pasted images (which can excee
 - **Location**: `~/.claude/projects/{sanitized-project-path}/{sessionId}.jsonl`
 - Each file is a JSONL stream of events with types `user`, `assistant`, `progress`, and others
 - `user` events contain the prompt; `assistant` events contain model responses and tool calls
+- `assistant` events may include `{ type: "thinking" }` content blocks (extended thinking) — these are surfaced as collapsible reasoning blocks in the conversation view
 - Sidechain events (warmup/internal) are filtered out automatically
 - Session title comes from the `slug` field (e.g. `happy-seeking-whistle`)
 

--- a/public/app.js
+++ b/public/app.js
@@ -279,7 +279,7 @@ function renderDetail(s) {
       const time = e.timestamp ? new Date(e.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "";
       const model = !isUser && modelAtIndex[i] ? `<span class="message-model">${escapeHtml(modelAtIndex[i])}</span>` : "";
       return `<div class="message ${isUser ? "message-user" : "message-assistant"}">
-        <div class="message-label">${isUser ? "👤 You" : "🤖 Copilot"}${model}${time ? `<span class="message-time">${time}</span>` : ""}</div>
+        <div class="message-label">${isUser ? "👤 You" : s.source === "claude-code" ? "🤖 Claude" : s.source === "vscode" ? "🤖 Copilot" : "🤖 Copilot"}${model}${time ? `<span class="message-time">${time}</span>` : ""}</div>
         <div class="message-body">${escapeHtml(display)}</div>
       </div>`;
     })

--- a/public/app.js
+++ b/public/app.js
@@ -265,10 +265,16 @@ function renderDetail(s) {
   // Interleave conversation messages in order
   const conversation = s.events
     .map((e, i) => ({ e, i }))
-    .filter(({ e }) => (e.type === "user.message" || e.type === "assistant.message") && (e.data?.content || "").trim())
+    .filter(({ e }) => (e.type === "user.message" || e.type === "assistant.message" || e.type === "assistant.thinking") && (e.data?.content || "").trim())
     .map(({ e, i }) => {
-      const isUser = e.type === "user.message";
       const content = e.data?.content || "";
+      if (e.type === "assistant.thinking") {
+        return `<details class="message message-thinking">
+          <summary class="thinking-toggle">💭 View thinking</summary>
+          <div class="thinking-body">${escapeHtml(content)}</div>
+        </details>`;
+      }
+      const isUser = e.type === "user.message";
       const display = content.length > 800 ? content.slice(0, 800) + "\n...(truncated)" : content;
       const time = e.timestamp ? new Date(e.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "";
       const model = !isUser && modelAtIndex[i] ? `<span class="message-model">${escapeHtml(modelAtIndex[i])}</span>` : "";
@@ -351,7 +357,9 @@ function renderDetail(s) {
       document.getElementById("panel-" + tab.dataset.tab).classList.add("active");
     });
   });
+
 }
+
 
 function escapeHtml(str) {
   const div = document.createElement("div");

--- a/public/style.css
+++ b/public/style.css
@@ -546,6 +546,41 @@ select:focus { box-shadow: 0 0 0 3px rgba(88,166,255,0.15); }
   margin-left: 6px;
 }
 
+.message-thinking {
+  align-self: flex-start;
+  max-width: 88%;
+  border-left: 3px solid var(--accent);
+  padding: 6px 10px;
+  border-radius: 6px;
+  background: transparent;
+  opacity: 0.7;
+}
+
+.thinking-toggle {
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.78rem;
+  font-family: inherit;
+  list-style: none;
+  user-select: none;
+}
+
+.thinking-toggle:hover {
+  text-decoration: underline;
+}
+
+.message-thinking summary::-webkit-details-marker { display: none; }
+
+.thinking-body {
+  font-size: 0.78rem;
+  color: var(--text-dim);
+  font-style: italic;
+  white-space: pre-wrap;
+  margin-top: 6px;
+  max-height: 400px;
+  overflow-y: auto;
+}
+
 /* Tool calls */
 .tool-card {
   display: flex;

--- a/src/__tests__/claude-code-sessions.test.ts
+++ b/src/__tests__/claude-code-sessions.test.ts
@@ -195,7 +195,7 @@ describe("listClaudeCodeSessions / getClaudeCodeSession / isClaudeCodeSession", 
     expect(detail!.title).toBe("test-slug");
   });
 
-  it("getClaudeCodeSession converts assistant text to assistant.message", () => {
+  it("getClaudeCodeSession converts assistant text to assistant.message and emits thinking events", () => {
     writeSession("sess-2", [
       makeEvent({ type: "user", isSidechain: false, sessionId: "sess-2", cwd: "/proj", slug: "s", timestamp: "2024-01-15T10:00:00Z", message: { content: "Hello" } }),
       makeEvent({ type: "assistant", isSidechain: false, sessionId: "sess-2", timestamp: "2024-01-15T10:00:05Z", message: { model: "claude-sonnet-4-6", content: [{ type: "thinking", thinking: "let me think" }, { type: "text", text: "World" }] } }),
@@ -206,6 +206,10 @@ describe("listClaudeCodeSessions / getClaudeCodeSession / isClaudeCodeSession", 
     expect(assistantEvents).toHaveLength(1);
     expect(assistantEvents[0].data.content).toBe("World");
     expect(assistantEvents[0].data.model).toBe("claude-sonnet-4-6");
+
+    const thinkingEvents = detail!.events.filter((e) => e.type === "assistant.thinking");
+    expect(thinkingEvents).toHaveLength(1);
+    expect(thinkingEvents[0].data.content).toBe("let me think");
   });
 
   it("getClaudeCodeSession emits tool.execution_start for each tool_use block", () => {

--- a/src/__tests__/vscode-sessions.test.ts
+++ b/src/__tests__/vscode-sessions.test.ts
@@ -158,7 +158,7 @@ describe("requestsToEvents", () => {
     expect(assistantMsg!.data.content).toBe("Answer from result");
   });
 
-  it("skips thinking parts from response text", () => {
+  it("emits assistant.thinking event for thinking parts and excludes them from response text", () => {
     const events = requestsToEvents([
       {
         requestId: "r5",
@@ -175,6 +175,10 @@ describe("requestsToEvents", () => {
     expect(assistantMsg).toBeDefined();
     expect(assistantMsg!.data.content).toBe("Final answer");
     expect(assistantMsg!.data.content).not.toContain("internal thought");
+
+    const thinkingEvent = events.find((e) => e.type === "assistant.thinking");
+    expect(thinkingEvent).toBeDefined();
+    expect(thinkingEvent!.data.content).toBe("internal thought process");
   });
 
   it("uses modelState.completedAt for response timestamp when available", () => {

--- a/src/claude-code-sessions.ts
+++ b/src/claude-code-sessions.ts
@@ -85,6 +85,13 @@ function extractToolUseBlocks(content: string | ContentBlock[] | undefined): Con
   return content.filter((b) => b.type === "tool_use");
 }
 
+function extractThinkingBlocks(content: string | ContentBlock[] | undefined): string[] {
+  if (!content || typeof content === "string") return [];
+  return content
+    .filter((b) => b.type === "thinking" && b.thinking)
+    .map((b) => b.thinking!);
+}
+
 function deriveStatus(lastTimestamp: string | undefined): SessionStatus {
   if (!lastTimestamp) return "completed";
   const age = Date.now() - new Date(lastTimestamp).getTime();
@@ -248,6 +255,16 @@ export function getClaudeCodeSession(sessionId: string): SessionDetail | null {
       }
     } else if (event.type === "assistant") {
       const msgContent = event.message?.content;
+
+      // Emit thinking blocks as assistant.thinking events
+      for (const thought of extractThinkingBlocks(msgContent)) {
+        events.push({
+          type: "assistant.thinking",
+          id: randomUUID(),
+          timestamp: ts,
+          data: { content: thought },
+        });
+      }
 
       // Emit tool_use blocks as tool.execution_start events
       for (const block of extractToolUseBlocks(msgContent)) {

--- a/src/vscode-sessions.ts
+++ b/src/vscode-sessions.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
+import { randomUUID } from "crypto";
 import Database from "better-sqlite3";
 import type { SessionMeta, SessionDetail, SessionEvent, SessionStatus } from "./sessions";
 import { cachedCall } from "./cache";
@@ -196,7 +197,15 @@ function requestsToEvents(requests: any[]): SessionEvent[] {
     const textParts: string[] = [];
     for (const part of response) {
       if (!part || typeof part !== "object") continue;
-      if (part.kind === "thinking" && part.value) continue; // skip thinking
+      if (part.kind === "thinking" && part.value) {
+        events.push({
+          type: "assistant.thinking",
+          id: randomUUID(),
+          timestamp: ts,
+          data: { content: part.value },
+        });
+        continue;
+      }
       if (!part.kind && typeof part.value === "string") {
         textParts.push(part.value);
       }


### PR DESCRIPTION
   ## Summary

   - **Thinking blocks rendered inline** — `assistant.thinking` events are now shown as collapsible `<details>` blocks between messages in the Conversation tab (collapsed by default,
   click "💭 View thinking" to expand)
   - **Claude Code** — extracts `{ type: "thinking" }` content blocks from assistant events in JSONL session files
   - **VS Code Copilot Chat** — extracts `{ kind: "thinking" }` response parts instead of discarding them
   - **Copilot CLI** — no change; the CLI does not persist thinking to disk
   - **Correct assistant label** — Claude Code conversation messages now show "🤖 Claude" instead of "🤖 Copilot"
   - **README updated** — documents thinking support per source and the CLI limitation

<img width="563" height="357" alt="Screenshot 2026-03-02 at 10 03 41 PM" src="https://github.com/user-attachments/assets/458213ee-bef3-4b75-b724-01909acd5717" />
