### PR TITLE
fix: show correct empty state when no sessions exist vs no filter matches

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -185,11 +185,21 @@ function renderSessions() {
   sessionCount.textContent = `${filtered.length} session${filtered.length !== 1 ? "s" : ""} found`;
 
   if (filtered.length === 0) {
-    sessionList.innerHTML = `
-      <div class="empty-state">
-        <span class="empty-icon">🔍</span>
-        <p>No sessions match your filters</p>
-      </div>`;
+    if (sessions.length === 0) {
+      sessionList.innerHTML = `
+        <div class="empty-state">
+          <span class="empty-icon">📂</span>
+          <p>No sessions found.</p>
+          <p style="font-size:0.85em;color:var(--text-muted)">Make sure you've used Copilot CLI, VS Code Copilot Chat, or Claude Code on this machine.<br>
+          See the <a href="https://github.com/pavanvamsi3/copilot-lens#readme" target="_blank">README</a> for supported tools and file paths.</p>
+        </div>`;
+    } else {
+      sessionList.innerHTML = `
+        <div class="empty-state">
+          <span class="empty-icon">🔍</span>
+          <p>No sessions match your filters</p>
+        </div>`;
+    }
     return;
   }
 

--- a/public/app.js
+++ b/public/app.js
@@ -186,18 +186,19 @@ function renderSessions() {
 
   if (filtered.length === 0) {
     if (sessions.length === 0) {
+      sessionCount.textContent = "";
       sessionList.innerHTML = `
         <div class="empty-state">
           <span class="empty-icon">📂</span>
           <p>No sessions found.</p>
-          <p style="font-size:0.85em;color:var(--text-muted)">Make sure you've used Copilot CLI, VS Code Copilot Chat, or Claude Code on this machine.<br>
+          <p class="empty-state-hint">Make sure you've used Copilot CLI, VS Code Copilot Chat, or Claude Code on this machine.<br>
           See the <a href="https://github.com/pavanvamsi3/copilot-lens#readme" target="_blank">README</a> for supported tools and file paths.</p>
         </div>`;
     } else {
       sessionList.innerHTML = `
         <div class="empty-state">
           <span class="empty-icon">🔍</span>
-          <p>No sessions match your filters</p>
+          <p>No sessions match your filters.</p>
         </div>`;
     }
     return;

--- a/public/style.css
+++ b/public/style.css
@@ -749,6 +749,11 @@ select:focus { box-shadow: 0 0 0 3px rgba(88,166,255,0.15); }
   line-height: 1.6;
 }
 
+.empty-state-hint {
+  font-size: 0.85em;
+  color: var(--text-muted);
+}
+
 /* Skeleton shimmer */
 @keyframes shimmer {
   0% { background-position: -200% 0; }


### PR DESCRIPTION
## Summary

- Fixes misleading empty state that showed "No sessions match your filters" even when the user has zero sessions (e.g. first-time use)
- Now shows two distinct messages: one for no data found at all, another for filters hiding results
- The no-data state includes guidance on supported tools and a link to the README

## What changed

`public/app.js` — `renderSessions()` function now checks `sessions.length === 0` (no data at all) separately from `filtered.length === 0` (filters hiding results).

## Test plan

- [ ] Run `copilot-lens` on a machine with no prior AI assistant sessions → should see "No sessions found" with README link
- [ ] Run with sessions present but filters set to hide all → should still see "No sessions match your filters"
- [ ] Run with sessions present and no filters → sessions list renders normally

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)