### PR TITLE
fix: replace inline error styles with .error-message CSS class

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -254,7 +254,7 @@ async function openDetail(id, source) {
     const session = await res.json();
     renderDetail(session);
   } catch (err) {
-    detailContent.innerHTML = `<div style="color:var(--danger)">Failed to load session: ${escapeHtml(err.message)}</div>`;
+    detailContent.innerHTML = `<div class="error-message">Failed to load session: ${escapeHtml(err.message)}</div>`;
   }
 }
 
@@ -362,7 +362,7 @@ function renderDetail(s) {
           ? errors
               .map(
                 (e) =>
-                  `<div class="message" style="border-left:3px solid var(--danger)"><div class="message-label" style="color:var(--danger)">Error</div>${escapeHtml(e.data?.message || "Unknown error")}</div>`
+                  `<div class="message message-error"><div class="message-label error-message">Error</div>${escapeHtml(e.data?.message || "Unknown error")}</div>`
               )
               .join("")
           : '<div style="color:var(--text-dim)">No errors 🎉</div>'
@@ -398,7 +398,7 @@ async function loadAnalytics() {
     analytics = await res.json();
     renderAnalytics();
   } catch (err) {
-    statsCards.innerHTML = `<div style="color:var(--danger)">Failed to load analytics</div>`;
+    statsCards.innerHTML = `<div class="error-message">Failed to load analytics</div>`;
   }
 }
 
@@ -600,7 +600,7 @@ async function loadSessions() {
     updateDirFilter();
     renderSessions();
   } catch (err) {
-    sessionList.innerHTML = `<div style="color:var(--danger);padding:20px">Failed to load sessions: ${escapeHtml(err.message)}</div>`;
+    sessionList.innerHTML = `<div class="error-message">Failed to load sessions: ${escapeHtml(err.message)}</div>`;
   }
 }
 
@@ -711,7 +711,7 @@ async function loadInsights() {
       renderInsightsScore(selected);
     }
   } catch (err) {
-    insightsContent.innerHTML = `<div style="color:var(--danger);padding:20px">Failed to load insights: ${escapeHtml(err.message)}</div>`;
+    insightsContent.innerHTML = `<div class="error-message">Failed to load insights: ${escapeHtml(err.message)}</div>`;
   }
 }
 
@@ -815,7 +815,7 @@ async function runSearch(q) {
     renderSearchResults(results);
   } catch (err) {
     isSearchActive = true;
-    sessionList.innerHTML = `<div style="color:var(--danger);padding:20px">Search failed: ${escapeHtml(err.message)}</div>`;
+    sessionList.innerHTML = `<div class="error-message">Search failed: ${escapeHtml(err.message)}</div>`;
   }
 }
 
@@ -983,7 +983,7 @@ async function loadTokens() {
     tokenData = await res.json();
     renderTokens();
   } catch (err) {
-    cards.innerHTML = `<div style="color:var(--danger)">Failed to load token usage: ${escapeHtml(err.message)}</div>`;
+    cards.innerHTML = `<div class="error-message">Failed to load token usage: ${escapeHtml(err.message)}</div>`;
   }
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -524,6 +524,10 @@ select:focus { box-shadow: 0 0 0 3px rgba(88,166,255,0.15); }
   overflow-y: auto;
 }
 
+.message-error {
+  border-left: 3px solid var(--danger);
+}
+
 .message-user {
   align-self: flex-end;
   background: color-mix(in srgb, var(--accent) 15%, var(--surface));
@@ -747,6 +751,11 @@ select:focus { box-shadow: 0 0 0 3px rgba(88,166,255,0.15); }
 .empty-state p {
   font-size: 0.95rem;
   line-height: 1.6;
+}
+
+.error-message {
+  color: var(--danger);
+  padding: 20px;
 }
 
 /* Skeleton shimmer */


### PR DESCRIPTION
## Summary

- Adds a reusable `.error-message` CSS class to `style.css` with `color: var(--danger)` and `padding: 20px`
- Adds a `.message-error` CSS class for the session detail error block (replaces `border-left:3px solid var(--danger)`)
- Replaces all 7 inline `style="color:var(--danger)"` instances in `app.js` with `class="error-message"`

## What changed

| File | Change |
|---|---|
| `public/style.css` | Added `.error-message` and `.message-error` classes |
| `public/app.js` | Replaced 7 inline error styles with CSS class references |

## Test plan

- [ ] Trigger an error state in each section (sessions, search, analytics, insights, tokens, session detail) and verify the error text still appears in red with correct padding
- [ ] Verify no visual regression compared to before the change

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)