### PR TITLE
fix: add expand/collapse toggle for truncated messages in session detail

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -296,12 +296,17 @@ function renderDetail(s) {
         </details>`;
       }
       const isUser = e.type === "user.message";
-      const display = content.length > 800 ? content.slice(0, 800) + "\n...(truncated)" : content;
+      const isTruncated = content.length > 800;
+      const msgId = `msg-${i}`;
       const time = e.timestamp ? new Date(e.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" }) : "";
       const model = !isUser && modelAtIndex[i] ? `<span class="message-model">${escapeHtml(modelAtIndex[i])}</span>` : "";
       return `<div class="message ${isUser ? "message-user" : "message-assistant"}">
         <div class="message-label">${isUser ? "👤 You" : s.source === "claude-code" ? "🤖 Claude" : s.source === "vscode" ? "🤖 Copilot" : "🤖 Copilot"}${model}${time ? `<span class="message-time">${time}</span>` : ""}</div>
-        <div class="message-body">${escapeHtml(display)}</div>
+        <div class="message-body">
+          <span id="${msgId}-short">${escapeHtml(content.slice(0, 800))}${isTruncated ? "…" : ""}</span>
+          ${isTruncated ? `<span id="${msgId}-full" style="display:none">${escapeHtml(content)}</span>` : ""}
+        </div>
+        ${isTruncated ? `<button class="show-more-btn" onclick="toggleMsg('${msgId}')">Show full message ↓</button>` : ""}
       </div>`;
     })
     .join("");
@@ -384,6 +389,16 @@ function renderDetail(s) {
 
 }
 
+
+function toggleMsg(id) {
+  const short = document.getElementById(id + "-short");
+  const full = document.getElementById(id + "-full");
+  const btn = short.closest(".message").querySelector(".show-more-btn");
+  const isExpanded = full.style.display !== "none";
+  short.style.display = isExpanded ? "" : "none";
+  full.style.display = isExpanded ? "none" : "";
+  btn.textContent = isExpanded ? "Show full message ↓" : "Show less ↑";
+}
 
 function escapeHtml(str) {
   const div = document.createElement("div");

--- a/public/style.css
+++ b/public/style.css
@@ -571,6 +571,20 @@ select:focus { box-shadow: 0 0 0 3px rgba(88,166,255,0.15); }
   margin-left: 6px;
 }
 
+.show-more-btn {
+  background: none;
+  border: none;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 0.8rem;
+  padding: 4px 0;
+  text-align: left;
+}
+
+.show-more-btn:hover {
+  text-decoration: underline;
+}
+
 .message-thinking {
   align-self: flex-start;
   max-width: 88%;


### PR DESCRIPTION
## Summary

Long messages (>800 chars) in the session detail view were hard-cut with `...(truncated)` and no way to read the rest. This PR replaces the static truncation with an inline expand/collapse toggle.

## Before / After

**Collapsed** — truncated message with "Show full message ↓" button:
![Collapsed](https://github.com/pavanvamsi3/copilot-lens/releases/download/untagged-bce1b19af240e5109bd9/message-truncation-collapsed.png)

**Expanded** — full message with "Show less ↑" button:
![Expanded](https://github.com/pavanvamsi3/copilot-lens/releases/download/untagged-bce1b19af240e5109bd9/message-truncation-expanded.png)

## What changed

**`public/app.js`**
- Renders the first 800 chars by default with a `…` indicator
- Adds a `Show full message ↓` button for truncated messages
- Adds a `toggleMsg()` function that swaps short/full content and updates the button label to `Show less ↑`

**`public/style.css`**
- Adds `.show-more-btn` styles — minimal, accent-coloured, underlines on hover

## Behaviour

| State | What user sees |
|---|---|
| Message ≤ 800 chars | Full content, no button |
| Message > 800 chars | First 800 chars + `…` + "Show full message ↓" button |
| After clicking expand | Full content + "Show less ↑" button |

## Test plan

- [ ] Open a session with long messages — should see truncated content + "Show full message ↓"
- [ ] Click the button — full message expands inline
- [ ] Click "Show less ↑" — collapses back to 800 chars
- [ ] Short messages (≤ 800 chars) — no button, no change in appearance

Closes #21