### PR TITLE
fix: update browser tab title when navigating between pages

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -48,9 +48,18 @@ const statsCards = document.getElementById("statsCards");
 
 // Navigation
 const VALID_PAGES = new Set(["home", "sessions", "analytics", "tokens", "insights", "docs"]);
+const PAGE_TITLES = {
+  home: "Copilot Lens",
+  sessions: "Sessions — Copilot Lens",
+  analytics: "Analytics — Copilot Lens",
+  tokens: "Tokens — Copilot Lens",
+  insights: "Insights — Copilot Lens",
+  docs: "Docs — Copilot Lens",
+};
 
 function activatePage(pageName) {
   if (!VALID_PAGES.has(pageName)) pageName = "home";
+  document.title = PAGE_TITLES[pageName] || "Copilot Lens";
   document.querySelectorAll(".nav-btn").forEach((b) => b.classList.remove("active"));
   document.querySelectorAll(".page").forEach((p) => p.classList.remove("active"));
   const btn = document.querySelector(`.nav-btn[data-page="${pageName}"]`);


### PR DESCRIPTION
## Summary

The browser tab always showed "Copilot Lens" regardless of which page was active. This PR adds a `PAGE_TITLES` map and sets `document.title` on every navigation so each page has a descriptive tab title.

## Verification

`document.title` returns the correct value in the console after each navigation, and the browser tab updates visually:

![Console verification — Analytics — Copilot Lens](https://github.com/pavanvamsi3/copilot-lens/releases/download/untagged-bce1b19af240e5109bd9/tab-title-console-verified.png)

**Sessions page:**
![Sessions tab title](https://github.com/pavanvamsi3/copilot-lens/releases/download/untagged-bce1b19af240e5109bd9/tab-title-sessions-verified.png)

## Page titles

| Page | Title |
|---|---|
| Home | `Copilot Lens` |
| Sessions | `Sessions — Copilot Lens` |
| Analytics | `Analytics — Copilot Lens` |
| Tokens | `Tokens — Copilot Lens` |
| Insights | `Insights — Copilot Lens` |
| Docs | `Docs — Copilot Lens` |

## What changed

`public/app.js` — added `PAGE_TITLES` constant and one `document.title` assignment at the top of `activatePage()`. No other files changed.

## Test plan

- [ ] Navigate to each tab — browser tab title should update accordingly
- [ ] Open two browser tabs to different pages — titles should be distinct
- [ ] Refresh on any page — title should match the current page on load

Closes #23