### PR TITLE
fix: highlight selected session card when detail pane is open

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -79,15 +79,21 @@ function switchToPage(pageName) {
   else location.hash = pageName;
 }
 
+function clearSelectedCard() {
+  document.querySelectorAll(".session-card.selected").forEach((c) => c.classList.remove("selected"));
+}
+
 // Side pane close
 paneClose.addEventListener("click", () => {
   detailPane.classList.remove("open");
+  clearSelectedCard();
 });
 
 // Keyboard shortcuts
 document.addEventListener("keydown", (e) => {
   if (e.key === "Escape" && detailPane.classList.contains("open")) {
     detailPane.classList.remove("open");
+    clearSelectedCard();
   }
   if (e.key === "/" && document.activeElement.tagName !== "INPUT" && document.activeElement.tagName !== "TEXTAREA") {
     e.preventDefault();
@@ -234,6 +240,9 @@ function renderSessions() {
 
 // Open session detail — side panel
 async function openDetail(id, source) {
+  clearSelectedCard();
+  const card = sessionList.querySelector(`.session-card[data-id="${id}"]`);
+  if (card) card.classList.add("selected");
   detailContent.innerHTML = `
     <div class="skeleton-card">
       <div class="skeleton-line" style="width:60%;height:16px;margin-bottom:12px"></div>

--- a/public/style.css
+++ b/public/style.css
@@ -240,6 +240,12 @@ select:focus { box-shadow: 0 0 0 3px rgba(88,166,255,0.15); }
   box-shadow: 0 8px 24px rgba(0,0,0,0.25);
 }
 
+.session-card.selected {
+  background: var(--surface2);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+
 @keyframes fadeSlideIn {
   from { opacity: 0; transform: translateY(6px); }
   to { opacity: 1; transform: translateY(0); }


### PR DESCRIPTION
## Summary

Adds a visual selected state to the session card that is currently open in the detail pane. Previously the active card looked identical to all others — a standard master-detail UI gap.

## What changed

**`public/style.css`** — adds `.session-card.selected` with an accent-coloured border and glow, matching the app's existing accent colour token

**`public/app.js`**
- `openDetail()` — clears any existing selection, then adds `.selected` to the clicked card
- Pane close button — clears selection on close
- Escape key handler — clears selection on close

## Behaviour

| Action | Result |
|---|---|
| Click a session card | Card gets accent border + highlight |
| Click a different card | Previous card deselects, new card selects |
| Close pane (✕ or Escape) | Selection clears |

## Screenshots

**After — selected card shows accent border highlight:**

![Selected session card with blue accent border](https://github.com/pavanvamsi3/copilot-lens/releases/download/untagged-17f77656d917ca904cc5/pr26-selected-card.png)

## Test plan

- [ ] Click any session card — it should get a blue border highlight
- [ ] Click a different card — highlight moves to the new card
- [ ] Close the detail pane with ✕ or Escape — highlight clears
- [ ] Works the same in search results and in the main session list

Closes #25