### PR TITLE
Support Copilot CLI session shutdown usage and premium requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ copilot-lens tokens --json    # Machine-readable output
 - **Search**: full-text across every session, with source/date/directory filters
 - **Sessions**: unified browser for Copilot CLI, VS Code Copilot Chat, and Claude Code conversations, including extended-thinking blocks where supported
 - **Analytics**: eight charts covering daily activity, hour-of-day, tools, models, top directories, time per branch/repo, and MCP servers
-- **Tokens**: real API-reported token usage parsed from local logs, with daily/weekly/monthly views, model breakdown, and an estimated upstream API cost
+- **Tokens**: real token usage parsed from local session data/logs, with daily/weekly/monthly views, model breakdown, Copilot premium requests, and an estimated upstream API cost reference for direct-API sources
 - **Effectiveness Score**: 0 to 100 score per repo with improvement tips
 - **Export**: single-session OpenAI-style chat JSONL, suitable as SFT data
 
@@ -49,14 +49,14 @@ copilot-lens tokens --json    # Machine-readable output
 
 ![0 to 100 score per repo with actionable improvement tips](https://raw.githubusercontent.com/pavanvamsi3/copilot-lens/main/assets/copilot-lens-score.png)
 
-> **About the cost number:** GitHub Copilot bills on **premium requests**, not tokens. The cost shown is what you'd pay calling Anthropic / OpenAI / Google directly with the same usage. Useful as a reference, not your GitHub bill.
+> **About pricing:** GitHub Copilot bills on **premium requests**, not raw token dollars. Copilot Lens now surfaces premium requests as the primary Copilot billing signal. Any API-cost figure is only a direct-provider reference for the underlying token usage, not your GitHub bill.
 
 ## Where the data comes from
 
 | Source | Path |
 |--------|------|
-| Copilot CLI sessions | `~/.copilot/session-state/` |
-| Copilot CLI token logs | `~/.copilot/logs/process-*.log` |
+| Copilot CLI sessions and usage summaries | `~/.copilot/session-state/` |
+| Copilot CLI legacy token logs | `~/.copilot/logs/process-*.log` |
 | VS Code Copilot Chat | `~/Library/Application Support/Code/` (macOS), `%APPDATA%/Code/` (Win), `~/.config/Code/` (Linux) |
 | Claude Code | `~/.claude/projects/` |
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
       <dd>Eight charts: daily activity, hour-of-day, tools, models, top directories, time per branch and repo, MCP servers.</dd>
 
       <dt>Tokens</dt>
-      <dd>Real API-reported token usage from local logs, with daily, weekly, and monthly views, model breakdown, and an estimated upstream cost.</dd>
+      <dd>Real token usage from local session data and logs, with daily, weekly, and monthly views, model breakdown, Copilot premium requests, and an estimated upstream API cost reference for direct-API sources.</dd>
 
       <dt>Effectiveness Score</dt>
       <dd>0 to 100 score per repo with actionable improvement tips covering prompt quality, tool utilization, efficiency, MCP, and engagement.</dd>
@@ -75,8 +75,8 @@ copilot-lens tokens --json</code></pre>
     <h2>Where the data comes from</h2>
     <p>Copilot Lens reads from local files only. No network requests, no telemetry.</p>
     <ul class="paths">
-      <li><span>Copilot CLI sessions</span><code>~/.copilot/session-state/</code></li>
-      <li><span>Copilot CLI token logs</span><code>~/.copilot/logs/process-*.log</code></li>
+      <li><span>Copilot CLI sessions and usage summaries</span><code>~/.copilot/session-state/</code></li>
+      <li><span>Copilot CLI legacy token logs</span><code>~/.copilot/logs/process-*.log</code></li>
       <li><span>VS Code Copilot Chat</span><code>~/Library/Application Support/Code/</code></li>
       <li><span>Claude Code</span><code>~/.claude/projects/</code></li>
     </ul>

--- a/public/app.js
+++ b/public/app.js
@@ -982,6 +982,10 @@ function estimateTotalCost() {
   return { cost, coverage: totalTokens > 0 ? coveredTokens / totalTokens : 0 };
 }
 
+function showPremiumRequestsMetric() {
+  return !!(tokenData && tokenSource !== "claude-code" && Number(tokenData.totals?.premium_requests || 0) > 0);
+}
+
 function formatUSD(n) {
   if (n == null) return "—";
   if (n >= 1000) return "$" + n.toFixed(0).replace(/\B(?=(\d{3})+(?!\d))/g, ",");
@@ -1024,6 +1028,7 @@ function renderTokens() {
   if (!tokenData) return;
   const t = tokenData.totals;
   const cards = document.getElementById("tokenStatsCards");
+  const showPremiumRequests = showPremiumRequestsMetric();
   const cacheRatePct = (t.cache_hit_rate * 100).toFixed(1) + "%";
   const promptShown = adjPrompt(t.prompt_tokens, t.cached_tokens);
   const totalShown = adjTotal(t.prompt_tokens, t.cached_tokens, t.completion_tokens);
@@ -1037,12 +1042,21 @@ function renderTokens() {
   const activeDays = t.active_days || 1;
   const avgPerDayShown = Math.round(totalShown / activeDays);
 
-  const est = estimateTotalCost();
-  const coveragePct = (est.coverage * 100).toFixed(0);
-  const costPerDay = activeDays > 0 ? est.cost / activeDays : 0;
-  const costSubLabel = est.coverage >= 0.99
-    ? `lifetime · ≈ ${formatUSD(costPerDay)} / day`
-    : `lifetime · ${coveragePct}% priced · ≈ ${formatUSD(costPerDay)} / day`;
+  let pricingCardHtml = "";
+  if (showPremiumRequests) {
+    const premiumLabel = tokenSource === "copilot-cli"
+      ? "Premium Requests · GitHub billing unit"
+      : "Premium Requests · Copilot CLI only";
+    pricingCardHtml = `<div class="stat-card" title="GitHub Copilot Business and Enterprise bill premium model usage with premium requests, not raw upstream API token prices. This value comes from your local Copilot CLI session data."><div class="stat-value">${formatTokens(t.premium_requests)}</div><div class="stat-label">${premiumLabel}</div></div>`;
+  } else {
+    const est = estimateTotalCost();
+    const coveragePct = (est.coverage * 100).toFixed(0);
+    const costPerDay = activeDays > 0 ? est.cost / activeDays : 0;
+    const costSubLabel = est.coverage >= 0.99
+      ? `lifetime · ≈ ${formatUSD(costPerDay)} / day`
+      : `lifetime · ${coveragePct}% priced · ≈ ${formatUSD(costPerDay)} / day`;
+    pricingCardHtml = `<div class="stat-card" title="Estimated cost if you called the underlying APIs (Anthropic, OpenAI, Google) directly with these token counts. This is NOT what GitHub Copilot bills you — Copilot uses premium requests against your monthly allowance. Aggregated across all parsed logs."><div class="stat-value">${formatUSD(est.cost)}</div><div class="stat-label">Est. API Cost · ${costSubLabel}</div></div>`;
+  }
 
   cards.innerHTML = `
     <div class="stat-card"><div class="stat-value">${formatTokens(totalShown)}</div><div class="stat-label">${totalLabel}</div></div>
@@ -1050,7 +1064,7 @@ function renderTokens() {
     <div class="stat-card"><div class="stat-value">${formatTokens(t.completion_tokens)}</div><div class="stat-label">Completion Tokens · ${compRatio} of prompt</div></div>
     <div class="stat-card"><div class="stat-value">${formatTokens(avgPerDayShown)}</div><div class="stat-label">Avg / Day · ${t.active_days} active day${t.active_days === 1 ? "" : "s"}</div></div>
     <div class="stat-card"><div class="stat-value" style="font-size:18px">${escapeHtml(t.top_model || "—")}</div><div class="stat-label">Top Model</div></div>
-    <div class="stat-card" title="Estimated cost if you called the underlying APIs (Anthropic, OpenAI, Google) directly with these token counts. This is NOT what GitHub Copilot bills you — Copilot uses 'premium requests' against your monthly allowance. Aggregated across all parsed logs."><div class="stat-value">${formatUSD(est.cost)}</div><div class="stat-label">Est. API Cost · ${costSubLabel}</div></div>
+    ${pricingCardHtml}
   `;
 
   const meta = document.getElementById("tokensMeta");
@@ -1175,6 +1189,7 @@ function bucketCost(b) {
 function renderTokenTable() {
   const table = document.getElementById("tokenBreakdownTable");
   if (!tokenData) { table.innerHTML = ""; return; }
+  const showPremiumRequests = showPremiumRequestsMetric();
   const buckets = (tokenData[tokenBucket] || []).slice().reverse();
   if (!buckets.length) { table.innerHTML = '<tbody><tr><td style="color:var(--text-dim);padding:20px">No data</td></tr></tbody>'; return; }
   const headerLabel = tokenBucket === "daily" ? "Day" : tokenBucket === "weekly" ? "Week" : "Month";
@@ -1188,7 +1203,7 @@ function renderTokenTable() {
       ${cachedHeader}
       <th>Completion</th>
       <th>Total</th>
-      <th>Est. Cost</th>
+      <th>${showPremiumRequests ? "Premium Requests" : "Est. API Cost"}</th>
       <th>Top Model</th>
     </tr></thead>
     <tbody>
@@ -1197,6 +1212,9 @@ function renderTokenTable() {
         const totalShown = adjTotal(b.prompt_tokens, b.cached_tokens, b.completion_tokens);
         const cachedCell = tokenIncludeCached ? `<td>${formatTokens(b.cached_tokens)}</td>` : "";
         const cost = bucketCost(b);
+        const pricingCell = showPremiumRequests
+          ? (b.premium_requests > 0 ? formatTokens(b.premium_requests) : '<span style="color:var(--text-dim)">—</span>')
+          : (cost == null ? '<span style="color:var(--text-dim)">—</span>' : formatUSD(cost));
         return `
         <tr>
           <td>${escapeHtml(b.period)}</td>
@@ -1205,7 +1223,7 @@ function renderTokenTable() {
           ${cachedCell}
           <td>${formatTokens(b.completion_tokens)}</td>
           <td><strong>${formatTokens(totalShown)}</strong></td>
-          <td>${cost == null ? '<span style="color:var(--text-dim)">—</span>' : formatUSD(cost)}</td>
+          <td>${pricingCell}</td>
           <td>${escapeHtml(b.top_model || "—")}</td>
         </tr>`;
       }).join("")}

--- a/public/index.html
+++ b/public/index.html
@@ -39,7 +39,7 @@
         <p>The <button class="home-link" data-jump="analytics">Analytics</button> tab has eight charts: sessions per day, hour of day, tool usage, model usage, top directories, time per branch, time per repo, and MCP servers. A source filter at the top applies to everything on the page so you can compare Copilot CLI vs Claude Code at a glance.</p>
 
         <h2>See where tokens go</h2>
-        <p>The <button class="home-link" data-jump="tokens">Tokens</button> tab shows daily, weekly, and monthly totals of input, output, and cached tokens, split by model. It also shows a rough cost estimate based on public API list prices. Curious how the numbers are built and what "cached" means? Read the <button class="home-link" data-jump="docs">Docs</button> tab.</p>
+        <p>The <button class="home-link" data-jump="tokens">Tokens</button> tab shows daily, weekly, and monthly totals of input, output, and cached tokens, split by model. For Copilot CLI it now shows <strong>premium requests</strong> as the primary billing signal; for Claude Code it still shows a rough upstream API cost reference. Curious how the numbers are built and what "cached" means? Read the <button class="home-link" data-jump="docs">Docs</button> tab.</p>
 
         <h2>Score each repo's effectiveness</h2>
         <p>The <button class="home-link" data-jump="insights">Insights</button> tab computes a per-repository score based on session outcomes, tool patterns, and time spent. A quick way to spot the codebases you are shipping in vs. the ones you are grinding through.</p>
@@ -202,15 +202,16 @@
 
         <h2>What Copilot CLI records</h2>
 
-        <p>GitHub Copilot CLI saves one log per day under <code>~/.copilot/logs</code>. Every AI response has a <code>usage</code> block with three numbers:</p>
+        <p>Current GitHub Copilot CLI sessions write token usage summaries under <code>~/.copilot/session-state/*/events.jsonl</code> in <code>session.shutdown</code> events. Older installs also wrote detailed response logs under <code>~/.copilot/logs</code>. Copilot Lens reads both shapes.</p>
 
         <dl>
-          <dt>prompt_tokens</dt><dd>Everything the model read this turn, cached or not.</dd>
-          <dt>completion_tokens</dt><dd>Everything the model wrote back.</dd>
-          <dt>cached_tokens</dt><dd>The part of prompt_tokens that came from cache, not fresh.</dd>
+          <dt>prompt_tokens</dt><dd>Everything the model read, including fresh input, cache writes, and cache reads.</dd>
+          <dt>completion_tokens</dt><dd>Everything the model wrote back, including reasoning/output tokens where the local session summary exposes them.</dd>
+          <dt>cached_tokens</dt><dd>The part of prompt_tokens that came from cache reads instead of fresh input.</dd>
+          <dt>premium_requests</dt><dd>The GitHub Copilot billing unit for premium model usage. This is the most relevant number for Copilot Business / Enterprise billing.</dd>
         </dl>
 
-        <p>Copilot itself does not bill you per token. It sells a subscription with a monthly budget of "premium requests". What you see here is the underlying model usage that Copilot makes on your behalf.</p>
+        <p>Copilot itself does not bill you per token. It sells a subscription with a monthly budget of premium requests. That is why the Tokens page now shows <strong>Premium Requests</strong> as the primary Copilot billing signal instead of pretending the raw token totals are your GitHub bill.</p>
 
         <p class="docs-links">
           <a href="https://github.com/features/copilot/plans" target="_blank" rel="noopener">Copilot plans and pricing</a>
@@ -256,17 +257,19 @@
           <a href="https://platform.openai.com/docs/guides/prompt-caching" target="_blank" rel="noopener">Prompt caching (OpenAI docs)</a>
         </p>
 
-        <h2>About the cost estimate</h2>
+        <h2>About pricing and premium requests</h2>
 
-        <p>The Est. API Cost number on the Tokens page uses the public list prices from each provider and multiplies them by the tokens we saw in your logs. It is a rough "what if you had called the API yourself" figure, not your actual bill.</p>
+        <p>When the Tokens page is showing <strong>Copilot CLI</strong> data, the pricing card now shows <strong>Premium Requests</strong>. That matches how GitHub Copilot Business / Enterprise meters premium model usage more closely than a raw token-to-dollar conversion.</p>
+
+        <p>When the Tokens page is showing <strong>Claude Code</strong> only, Copilot Lens still shows an <strong>Est. API Cost</strong> figure based on public API list prices, because Claude Code is a direct API-style token meter. In mixed views, Copilot Lens prefers Premium Requests if Copilot billing data is present.</p>
 
         <p>Caveats:</p>
 
         <ul class="docs-list">
-          <li>It is not what GitHub Copilot charges. Copilot sells a subscription and uses a premium request budget; that budget is cheaper than calling the underlying APIs directly.</li>
-          <li>It is not what Claude.ai or ChatGPT subscriptions charge. Same reason.</li>
-          <li>Cache creation is billed higher than cache reads. Copilot Lens approximates this but does not match to the exact penny.</li>
-          <li>Unknown model names count as zero cost. The "% priced" label tells you how much of the total had a known rate.</li>
+          <li>Premium Requests are the right unit for Copilot plan usage, but they are still not a full invoice. Seat pricing and any org-level allowances live outside these local logs.</li>
+          <li>Est. API Cost is only a reference model for direct provider pricing. It is not what GitHub Copilot, Claude.ai, or ChatGPT subscriptions charge.</li>
+          <li>Cache creation is billed higher than cache reads on direct APIs. Copilot Lens approximates this for API-style references but does not match provider invoices to the exact penny.</li>
+          <li>Unknown model names count as zero in API-cost mode. The "% priced" label tells you how much of the total had a known rate.</li>
         </ul>
 
         <p class="docs-links">
@@ -278,7 +281,8 @@
         <h2>Where the data lives</h2>
 
         <dl>
-          <dt>~/.copilot/logs/</dt><dd>Copilot CLI response logs.</dd>
+          <dt>~/.copilot/session-state/</dt><dd>Copilot CLI session summaries, including <code>session.shutdown</code> usage and premium-request data.</dd>
+          <dt>~/.copilot/logs/</dt><dd>Legacy Copilot CLI response logs.</dd>
           <dt>~/.claude/projects/</dt><dd>Claude Code JSONL session files, one folder per working directory.</dd>
         </dl>
 

--- a/src/__tests__/token-usage.test.ts
+++ b/src/__tests__/token-usage.test.ts
@@ -110,6 +110,7 @@ describe("parseCopilotCliEventsJsonl", () => {
       request_id: "session-1:gpt-5.4",
       model: "gpt-5.4",
       call_count: 3,
+      premium_requests: 1,
       prompt_tokens: 1450,
       completion_tokens: 125,
       cached_tokens: 400,
@@ -147,7 +148,10 @@ describe("aggregate", () => {
     const calls = parseCopilotCliEventsJsonl(SESSION_SHUTDOWN);
     const agg = aggregate(calls, 1, "/tmp");
     expect(agg.totals.calls).toBe(3);
+    expect(agg.totals.premium_requests).toBe(1);
     expect(agg.byModel["gpt-5.4"].calls).toBe(3);
+    expect(agg.byModel["gpt-5.4"].premium_requests).toBe(1);
     expect(agg.daily[0].calls).toBe(3);
+    expect(agg.daily[0].premium_requests).toBe(1);
   });
 });

--- a/src/__tests__/token-usage.test.ts
+++ b/src/__tests__/token-usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { parseLogContent, normalizeModelName, aggregate } from "../token-usage";
+import { parseLogContent, parseCopilotCliEventsJsonl, normalizeModelName, aggregate } from "../token-usage";
 import { clearCache } from "../cache";
 
 const RESPONSE_BLOCK = `2026-01-22T18:34:17.358Z [DEBUG] response (Request-ID 00000-abc):
@@ -48,6 +48,8 @@ const FALSE_POSITIVE = `2026-01-22T18:00:00.000Z [DEBUG] request config: {
   "model": "claude-opus-4.7"
 }
 `;
+
+const SESSION_SHUTDOWN = `{"type":"session.shutdown","data":{"shutdownType":"routine","totalPremiumRequests":1,"totalApiDurationMs":12345,"sessionStartTime":1778222867017,"modelMetrics":{"gpt-5.4":{"requests":{"count":3,"cost":1},"usage":{"inputTokens":1000,"outputTokens":100,"cacheReadTokens":400,"cacheWriteTokens":50,"reasoningTokens":25}}}},"id":"session-1","timestamp":"2026-05-08T06:49:22.344Z"}`;
 
 describe("normalizeModelName", () => {
   it("strips capi: prefix and option suffix", () => {
@@ -98,6 +100,24 @@ describe("parseLogContent", () => {
   });
 });
 
+describe("parseCopilotCliEventsJsonl", () => {
+  beforeEach(() => clearCache());
+
+  it("extracts session shutdown model metrics from events.jsonl", () => {
+    const calls = parseCopilotCliEventsJsonl(SESSION_SHUTDOWN);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      request_id: "session-1:gpt-5.4",
+      model: "gpt-5.4",
+      call_count: 3,
+      prompt_tokens: 1450,
+      completion_tokens: 125,
+      cached_tokens: 400,
+      total_tokens: 1575,
+    });
+  });
+});
+
 describe("aggregate", () => {
   it("computes totals, model breakdown, and bucket data", () => {
     const calls = parseLogContent(RESPONSE_BLOCK + RESPONSE_NO_MODEL);
@@ -121,5 +141,13 @@ describe("aggregate", () => {
     expect(agg.totals.cache_hit_rate).toBe(0);
     expect(agg.totals.top_model).toBeNull();
     expect(agg.daily).toEqual([]);
+  });
+
+  it("uses weighted call counts from session shutdown metrics", () => {
+    const calls = parseCopilotCliEventsJsonl(SESSION_SHUTDOWN);
+    const agg = aggregate(calls, 1, "/tmp");
+    expect(agg.totals.calls).toBe(3);
+    expect(agg.byModel["gpt-5.4"].calls).toBe(3);
+    expect(agg.daily[0].calls).toBe(3);
   });
 });

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -12,6 +12,7 @@ export interface TokenCall {
   message_id?: string;
   model: string;
   source: TokenSource;
+  call_count: number;
   prompt_tokens: number;
   completion_tokens: number;
   cached_tokens: number;
@@ -71,6 +72,10 @@ const MODEL_LOOKBACK_RE = /"model"\s*:\s*"([^"]+)"/;
 
 export function getLogsDir(): string {
   return path.join(os.homedir(), ".copilot", "logs");
+}
+
+export function getSessionStateDir(): string {
+  return path.join(os.homedir(), ".copilot", "session-state");
 }
 
 /**
@@ -175,6 +180,7 @@ export function parseLogContent(content: string): TokenCall[] {
       message_id: typeof parsed.id === "string" ? parsed.id : undefined,
       model,
       source: "copilot-cli",
+      call_count: 1,
       prompt_tokens: usage.prompt_tokens,
       completion_tokens: usage.completion_tokens,
       cached_tokens: cached,
@@ -237,7 +243,7 @@ function bucketize(calls: TokenCall[], keyFn: (c: TokenCall) => string): PeriodB
       b = emptyBucket(k);
       map.set(k, b);
     }
-    b.calls += 1;
+    b.calls += c.call_count || 1;
     b.prompt_tokens += c.prompt_tokens;
     b.cached_tokens += c.cached_tokens;
     b.completion_tokens += c.completion_tokens;
@@ -308,12 +314,69 @@ export function parseClaudeCodeJsonl(content: string): TokenCall[] {
       message_id: typeof msg?.id === "string" ? msg.id : undefined,
       model: normalizeModelName(model),
       source: "claude-code",
+      call_count: 1,
       prompt_tokens: prompt,
       completion_tokens: output,
       cached_tokens: cacheRead,
       total_tokens: total,
     });
   }
+  return out;
+}
+
+export function parseCopilotCliEventsJsonl(content: string): TokenCall[] {
+  const out: TokenCall[] = [];
+
+  for (const line of content.split("\n")) {
+    if (!line.trim()) continue;
+
+    let ev: any;
+    try {
+      ev = JSON.parse(line);
+    } catch {
+      continue;
+    }
+
+    if (ev?.type !== "session.shutdown") continue;
+
+    const timestamp =
+      typeof ev.timestamp === "string"
+        ? ev.timestamp
+        : typeof ev?.data?.sessionStartTime === "number"
+          ? new Date(ev.data.sessionStartTime).toISOString()
+          : "";
+
+    const modelMetrics = ev?.data?.modelMetrics;
+    if (!modelMetrics || typeof modelMetrics !== "object") continue;
+
+    for (const [rawModel, metric] of Object.entries(modelMetrics as Record<string, any>)) {
+      const usage = metric?.usage;
+      if (!usage || typeof usage !== "object") continue;
+
+      const input = Number(usage.inputTokens || 0);
+      const output = Number(usage.outputTokens || 0);
+      const cacheRead = Number(usage.cacheReadTokens || 0);
+      const cacheWrite = Number(usage.cacheWriteTokens || 0);
+      const reasoning = Number(usage.reasoningTokens || 0);
+      const prompt = input + cacheRead + cacheWrite;
+      const completion = output + reasoning;
+      const total = prompt + completion;
+      if (total === 0) continue;
+
+      out.push({
+        timestamp,
+        request_id: `${ev.id || "session-shutdown"}:${rawModel}`,
+        model: normalizeModelName(rawModel),
+        source: "copilot-cli",
+        call_count: Math.max(1, Number(metric?.requests?.count || 1)),
+        prompt_tokens: prompt,
+        completion_tokens: completion,
+        cached_tokens: cacheRead,
+        total_tokens: total,
+      });
+    }
+  }
+
   return out;
 }
 
@@ -342,9 +405,31 @@ function listClaudeCodeJsonlFiles(dir: string): string[] {
   return out;
 }
 
+function listSessionEventFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+
+  let subdirs: fs.Dirent[];
+  try {
+    subdirs = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  for (const sub of subdirs) {
+    if (!sub.isDirectory()) continue;
+    const eventsPath = path.join(dir, sub.name, "events.jsonl");
+    if (fs.existsSync(eventsPath)) out.push(eventsPath);
+  }
+
+  return out;
+}
+
 function collectCopilotCli(): { calls: TokenCall[]; logsScanned: number; logsDir: string } {
-  const dir = getLogsDir();
-  const files = listLogFiles(dir);
+  const logsDir = getLogsDir();
+  const sessionDir = getSessionStateDir();
+  const files = listLogFiles(logsDir);
+  const eventFiles = listSessionEventFiles(sessionDir);
   const calls: TokenCall[] = [];
   for (const f of files) {
     try {
@@ -354,7 +439,19 @@ function collectCopilotCli(): { calls: TokenCall[]; logsScanned: number; logsDir
       // skip unreadable files
     }
   }
-  return { calls, logsScanned: files.length, logsDir: dir };
+  for (const f of eventFiles) {
+    try {
+      const content = fs.readFileSync(f, "utf-8");
+      for (const c of parseCopilotCliEventsJsonl(content)) calls.push(c);
+    } catch {
+      // skip unreadable files
+    }
+  }
+  return {
+    calls,
+    logsScanned: files.length + eventFiles.length,
+    logsDir: `${logsDir}, ${sessionDir}`,
+  };
 }
 
 function collectClaudeCode(): { calls: TokenCall[]; logsScanned: number; logsDir: string } {
@@ -376,12 +473,14 @@ function collectClaudeCode(): { calls: TokenCall[]; logsScanned: number; logsDir
 
 export function aggregate(calls: TokenCall[], logsScanned: number, logsDir: string): TokenUsageAnalytics {
   const byModel: TokenUsageAnalytics["byModel"] = {};
+  let callCount = 0;
   let prompt = 0;
   let cached = 0;
   let completion = 0;
   let total = 0;
 
   for (const c of calls) {
+    callCount += c.call_count || 1;
     prompt += c.prompt_tokens;
     cached += c.cached_tokens;
     completion += c.completion_tokens;
@@ -393,7 +492,7 @@ export function aggregate(calls: TokenCall[], logsScanned: number, logsDir: stri
       completion_tokens: 0,
       total_tokens: 0,
     });
-    m.calls += 1;
+    m.calls += c.call_count || 1;
     m.prompt_tokens += c.prompt_tokens;
     m.cached_tokens += c.cached_tokens;
     m.completion_tokens += c.completion_tokens;
@@ -419,7 +518,7 @@ export function aggregate(calls: TokenCall[], logsScanned: number, logsDir: stri
 
   return {
     totals: {
-      calls: calls.length,
+      calls: callCount,
       prompt_tokens: prompt,
       cached_tokens: cached,
       completion_tokens: completion,
@@ -446,8 +545,18 @@ export function getTokenUsage(source: TokenSourceFilter = "all"): TokenUsageAnal
     const cc = collectClaudeCode();
 
     const sourcesSummary: TokenUsageAnalytics["sources"] = [
-      { source: "copilot-cli", logsDir: cli.logsDir, logsScanned: cli.logsScanned, calls: cli.calls.length },
-      { source: "claude-code", logsDir: cc.logsDir, logsScanned: cc.logsScanned, calls: cc.calls.length },
+      {
+        source: "copilot-cli",
+        logsDir: cli.logsDir,
+        logsScanned: cli.logsScanned,
+        calls: cli.calls.reduce((sum, call) => sum + (call.call_count || 1), 0),
+      },
+      {
+        source: "claude-code",
+        logsDir: cc.logsDir,
+        logsScanned: cc.logsScanned,
+        calls: cc.calls.reduce((sum, call) => sum + (call.call_count || 1), 0),
+      },
     ];
 
     let selected: TokenCall[];

--- a/src/token-usage.ts
+++ b/src/token-usage.ts
@@ -13,6 +13,7 @@ export interface TokenCall {
   model: string;
   source: TokenSource;
   call_count: number;
+  premium_requests: number;
   prompt_tokens: number;
   completion_tokens: number;
   cached_tokens: number;
@@ -22,12 +23,14 @@ export interface TokenCall {
 export interface PeriodBucket {
   period: string;
   calls: number;
+  premium_requests: number;
   prompt_tokens: number;
   cached_tokens: number;
   completion_tokens: number;
   total_tokens: number;
   top_model: string;
   models: Record<string, {
+    premium_requests: number;
     prompt_tokens: number;
     cached_tokens: number;
     completion_tokens: number;
@@ -38,6 +41,7 @@ export interface PeriodBucket {
 export interface TokenUsageAnalytics {
   totals: {
     calls: number;
+    premium_requests: number;
     prompt_tokens: number;
     cached_tokens: number;
     completion_tokens: number;
@@ -49,6 +53,7 @@ export interface TokenUsageAnalytics {
   };
   byModel: Record<string, {
     calls: number;
+    premium_requests: number;
     prompt_tokens: number;
     cached_tokens: number;
     completion_tokens: number;
@@ -181,6 +186,7 @@ export function parseLogContent(content: string): TokenCall[] {
       model,
       source: "copilot-cli",
       call_count: 1,
+      premium_requests: 0,
       prompt_tokens: usage.prompt_tokens,
       completion_tokens: usage.completion_tokens,
       cached_tokens: cached,
@@ -224,6 +230,7 @@ function emptyBucket(period: string): PeriodBucket & { _models: Record<string, n
   return {
     period,
     calls: 0,
+    premium_requests: 0,
     prompt_tokens: 0,
     cached_tokens: 0,
     completion_tokens: 0,
@@ -244,17 +251,20 @@ function bucketize(calls: TokenCall[], keyFn: (c: TokenCall) => string): PeriodB
       map.set(k, b);
     }
     b.calls += c.call_count || 1;
+    b.premium_requests += c.premium_requests || 0;
     b.prompt_tokens += c.prompt_tokens;
     b.cached_tokens += c.cached_tokens;
     b.completion_tokens += c.completion_tokens;
     b.total_tokens += c.total_tokens;
     b._models[c.model] = (b._models[c.model] || 0) + c.total_tokens;
     const mb = (b.models[c.model] = b.models[c.model] || {
+      premium_requests: 0,
       prompt_tokens: 0,
       cached_tokens: 0,
       completion_tokens: 0,
       total_tokens: 0,
     });
+    mb.premium_requests += c.premium_requests || 0;
     mb.prompt_tokens += c.prompt_tokens;
     mb.cached_tokens += c.cached_tokens;
     mb.completion_tokens += c.completion_tokens;
@@ -315,6 +325,7 @@ export function parseClaudeCodeJsonl(content: string): TokenCall[] {
       model: normalizeModelName(model),
       source: "claude-code",
       call_count: 1,
+      premium_requests: 0,
       prompt_tokens: prompt,
       completion_tokens: output,
       cached_tokens: cacheRead,
@@ -348,8 +359,9 @@ export function parseCopilotCliEventsJsonl(content: string): TokenCall[] {
 
     const modelMetrics = ev?.data?.modelMetrics;
     if (!modelMetrics || typeof modelMetrics !== "object") continue;
+    const modelMetricEntries = Object.entries(modelMetrics as Record<string, any>);
 
-    for (const [rawModel, metric] of Object.entries(modelMetrics as Record<string, any>)) {
+    for (const [rawModel, metric] of modelMetricEntries) {
       const usage = metric?.usage;
       if (!usage || typeof usage !== "object") continue;
 
@@ -358,6 +370,13 @@ export function parseCopilotCliEventsJsonl(content: string): TokenCall[] {
       const cacheRead = Number(usage.cacheReadTokens || 0);
       const cacheWrite = Number(usage.cacheWriteTokens || 0);
       const reasoning = Number(usage.reasoningTokens || 0);
+      const requestCost = Number(metric?.requests?.cost);
+      const totalPremiumRequests = Number(ev?.data?.totalPremiumRequests);
+      const premiumRequests = Number.isFinite(requestCost)
+        ? Math.max(0, requestCost)
+        : modelMetricEntries.length === 1 && Number.isFinite(totalPremiumRequests)
+          ? Math.max(0, totalPremiumRequests)
+          : 0;
       const prompt = input + cacheRead + cacheWrite;
       const completion = output + reasoning;
       const total = prompt + completion;
@@ -369,6 +388,7 @@ export function parseCopilotCliEventsJsonl(content: string): TokenCall[] {
         model: normalizeModelName(rawModel),
         source: "copilot-cli",
         call_count: Math.max(1, Number(metric?.requests?.count || 1)),
+        premium_requests: premiumRequests,
         prompt_tokens: prompt,
         completion_tokens: completion,
         cached_tokens: cacheRead,
@@ -474,6 +494,7 @@ function collectClaudeCode(): { calls: TokenCall[]; logsScanned: number; logsDir
 export function aggregate(calls: TokenCall[], logsScanned: number, logsDir: string): TokenUsageAnalytics {
   const byModel: TokenUsageAnalytics["byModel"] = {};
   let callCount = 0;
+  let premiumRequests = 0;
   let prompt = 0;
   let cached = 0;
   let completion = 0;
@@ -481,18 +502,21 @@ export function aggregate(calls: TokenCall[], logsScanned: number, logsDir: stri
 
   for (const c of calls) {
     callCount += c.call_count || 1;
+    premiumRequests += c.premium_requests || 0;
     prompt += c.prompt_tokens;
     cached += c.cached_tokens;
     completion += c.completion_tokens;
     total += c.total_tokens;
     const m = (byModel[c.model] = byModel[c.model] || {
       calls: 0,
+      premium_requests: 0,
       prompt_tokens: 0,
       cached_tokens: 0,
       completion_tokens: 0,
       total_tokens: 0,
     });
     m.calls += c.call_count || 1;
+    m.premium_requests += c.premium_requests || 0;
     m.prompt_tokens += c.prompt_tokens;
     m.cached_tokens += c.cached_tokens;
     m.completion_tokens += c.completion_tokens;
@@ -519,6 +543,7 @@ export function aggregate(calls: TokenCall[], logsScanned: number, logsDir: stri
   return {
     totals: {
       calls: callCount,
+      premium_requests: premiumRequests,
       prompt_tokens: prompt,
       cached_tokens: cached,
       completion_tokens: completion,


### PR DESCRIPTION
## Summary
- add Copilot CLI usage parsing for `~/.copilot/session-state/*/events.jsonl` `session.shutdown` events
- preserve the legacy `~/.copilot/logs/process-*.log` parser
- surface Copilot premium requests as the primary billing signal instead of showing misleading raw API-dollar estimates for Copilot usage
- keep direct API cost as a reference for non-Copilot sources
- add tests for the new parser and weighted aggregate counts
- update dashboard/docs wording to match Copilot Business billing more closely

## Why
Recent Copilot CLI versions no longer expose token usage through the legacy debug log blocks this project currently parses. On a current local install, the Tokens tab stayed empty even though usage data was present in `session.shutdown.data.modelMetrics` within `events.jsonl`.

Separately, showing public Anthropic/OpenAI/Google API prices as the main Copilot number is misleading for Copilot Business users, because GitHub bills premium model usage in premium requests rather than raw API token dollars.

This change keeps the existing legacy parser in place, adds support for the newer session-state format, and makes the Copilot billing UI use premium requests as the primary metric.

## Validation
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" npm run build`
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" npm test`
- `PATH="/opt/homebrew/opt/node@20/bin:$PATH" node -e "const { getTokenUsage } = require('./dist/token-usage.js'); const data = getTokenUsage('copilot-cli'); console.log(JSON.stringify({ premium_requests: data.totals.premium_requests, calls: data.totals.calls }, null, 2));"` returned non-zero Copilot CLI totals locally

## Scope
This PR only includes reusable parser, UI, and docs changes. Local-only helper files were not included.