### PR TITLE
ci: run unit tests automatically on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [20.x, 22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run unit tests
+        run: npm test


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` — a GitHub Actions workflow that runs the existing Vitest test suite on every PR and push to `main`
- Tests run against Node.js **20.x** and **22.x** to catch version-specific issues
- Uses `npm ci` for clean, reproducible installs in CI
- All **114 existing tests pass** across 7 test files

## Why

The project already has solid test coverage but no CI to enforce it. Without this, tests only run locally — contributors can unknowingly merge broken code and reviewers have no automated signal. This makes the existing test suite a real quality gate.

Closes #33

## Test plan

- [x] `npm test` runs locally — 7 test files, 114 tests, all passing
- [ ] GitHub Actions workflow triggers on this PR and shows green
- [ ] Verify matrix runs for both Node.js 20.x and 22.x succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)