### PR TITLE
chore: add .gitattributes to enforce consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,22 @@
+# Auto detect text files and ensure LF line endings across all platforms
+* text=auto eol=lf
+
+# Explicitly declare text file types to enforce LF
+*.sh text eol=lf
+*.ts text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.md text eol=lf
+*.css text eol=lf
+*.html text eol=lf
+*.cmd text eol=crlf
+
+# Binary files — do not modify
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.svg binary


### PR DESCRIPTION
## Summary

Adds a `.gitattributes` file to enforce LF line endings across all platforms.

Fixes #64

## Changes

- `* text=auto eol=lf` auto-detect text files and normalize to LF
- Explicit LF rules for .sh, .ts, .js, .json, .yml, .yaml, .md, .css, .html
- CRLF preserved for .cmd files (required by Windows batch interpreter)
- Binary rules for image files (.png, .jpg, .jpeg, .gif, .ico, .svg)

## Why

- Prevents spurious whitespace-only diffs from Windows contributors
- Standard practice for cross-platform Node.js projects
- Config-only change, no code modifications