### PR TITLE
feat: weekly usage digest CLI command

### DIFF
--- a/src/__tests__/cli-digest.test.ts
+++ b/src/__tests__/cli-digest.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { parseDigestArgs } from "../cli-digest";
+import { getDigest } from "../digest";
 
 describe("parseDigestArgs", () => {
   it("defaults to week period, no flags", () => {
@@ -38,5 +39,57 @@ describe("parseDigestArgs", () => {
 
   it("last flag wins for period", () => {
     expect(parseDigestArgs(["--month", "--last-week"]).period).toBe("last-week");
+  });
+});
+
+describe("getDigest", () => {
+  it("returns all required fields for week period", () => {
+    const data = getDigest("week");
+    expect(typeof data.rangeLabel).toBe("string");
+    expect(data.rangeLabel.length).toBeGreaterThan(0);
+    expect(typeof data.activeDays).toBe("number");
+    expect(typeof data.totalDays).toBe("number");
+    expect(typeof data.sessions).toBe("number");
+    expect(typeof data.totalDurationMs).toBe("number");
+    expect(typeof data.totalTokens).toBe("number");
+    expect(typeof data.priorSessions).toBe("number");
+  });
+
+  it("week totalDays is always 7", () => {
+    expect(getDigest("week").totalDays).toBe(7);
+    expect(getDigest("last-week").totalDays).toBe(7);
+  });
+
+  it("rangeLabel contains 'Week of' for week periods", () => {
+    expect(getDigest("week").rangeLabel).toMatch(/Week of/);
+    expect(getDigest("last-week").rangeLabel).toMatch(/Week of/);
+  });
+
+  it("month totalDays is between 28 and 31", () => {
+    const data = getDigest("month");
+    expect(data.totalDays).toBeGreaterThanOrEqual(28);
+    expect(data.totalDays).toBeLessThanOrEqual(31);
+  });
+
+  it("priorTokens is null or a non-negative number", () => {
+    const data = getDigest("week");
+    expect(data.priorTokens === null || typeof data.priorTokens === "number").toBe(true);
+    if (data.priorTokens !== null) expect(data.priorTokens).toBeGreaterThanOrEqual(0);
+  });
+
+  it("longestSession is null or has the correct shape", () => {
+    const data = getDigest("week");
+    if (data.longestSession !== null) {
+      expect(typeof data.longestSession.durationMs).toBe("number");
+      expect(typeof data.longestSession.turns).toBe("number");
+      expect(data.longestSession.durationMs).toBeGreaterThan(0);
+    }
+  });
+
+  it("startDate and endDate are valid ISO date strings", () => {
+    const data = getDigest("week");
+    expect(data.startDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(data.endDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(new Date(data.startDate).getTime()).toBeLessThanOrEqual(new Date(data.endDate).getTime());
   });
 });

--- a/src/__tests__/cli-digest.test.ts
+++ b/src/__tests__/cli-digest.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { parseDigestArgs } from "../cli-digest";
+
+describe("parseDigestArgs", () => {
+  it("defaults to week period, no flags", () => {
+    expect(parseDigestArgs([])).toEqual({ period: "week", save: false, json: false, help: false });
+  });
+
+  it("parses --last-week", () => {
+    expect(parseDigestArgs(["--last-week"]).period).toBe("last-week");
+  });
+
+  it("parses --month", () => {
+    expect(parseDigestArgs(["--month"]).period).toBe("month");
+  });
+
+  it("parses --save", () => {
+    expect(parseDigestArgs(["--save"]).save).toBe(true);
+  });
+
+  it("parses --json", () => {
+    expect(parseDigestArgs(["--json"]).json).toBe(true);
+  });
+
+  it("parses --help and -h", () => {
+    expect(parseDigestArgs(["--help"]).help).toBe(true);
+    expect(parseDigestArgs(["-h"]).help).toBe(true);
+  });
+
+  it("parses combined flags", () => {
+    expect(parseDigestArgs(["--last-week", "--save", "--json"])).toEqual({
+      period: "last-week",
+      save: true,
+      json: true,
+      help: false,
+    });
+  });
+
+  it("last flag wins for period", () => {
+    expect(parseDigestArgs(["--month", "--last-week"]).period).toBe("last-week");
+  });
+});

--- a/src/cli-digest.tsx
+++ b/src/cli-digest.tsx
@@ -34,11 +34,11 @@ function changeBadge(current: number, prior: number | null): string | null {
 
 type Row = { icon: string; label: string; value: string; badge?: string };
 
-function DigestApp({ period }: { period: DigestPeriod }) {
-  const [data, setData] = useState<DigestData | null>(null);
+function DigestApp({ period, precomputed }: { period: DigestPeriod; precomputed?: DigestData }) {
+  const [data, setData] = useState<DigestData | null>(precomputed ?? null);
 
   useEffect(() => {
-    setData(getDigest(period));
+    if (!precomputed) setData(getDigest(period));
   }, [period]);
 
   if (!data) return <Text dimColor>Computing digest…</Text>;
@@ -152,7 +152,7 @@ function toMarkdown(data: DigestData): string {
 const HELP = `
   Usage: copilot-lens digest [options]
 
-  Print a weekly usage summary to the terminal (Spotify Wrapped-style).
+  Print a period-based usage summary to the terminal (Spotify Wrapped-style).
 
   Options:
     --last-week   Show last week instead of the current week
@@ -202,8 +202,15 @@ export function runDigestTUI(argv: string[]): void {
     const data = getDigest(opts.period);
     const md = toMarkdown(data);
     const outPath = path.join(process.cwd(), "digest.md");
-    fs.writeFileSync(outPath, md, "utf-8");
-    process.stderr.write(`Saved digest to ${outPath}\n`);
+    try {
+      fs.writeFileSync(outPath, md, "utf-8");
+      process.stderr.write(`Saved digest to ${outPath}\n`);
+    } catch (err: any) {
+      process.stderr.write(`Error: could not save digest to ${outPath}: ${err?.message || err}\n`);
+      process.exitCode = 1;
+    }
+    render(<DigestApp period={opts.period} precomputed={data} />);
+    return;
   }
 
   render(<DigestApp period={opts.period} />);

--- a/src/cli-digest.tsx
+++ b/src/cli-digest.tsx
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+
+import React, { useState, useEffect } from "react";
+import { render, Text, Box, Newline } from "ink";
+import * as fs from "fs";
+import * as path from "path";
+import { getDigest, DigestPeriod, DigestData } from "./digest";
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+function fmtMs(ms: number): string {
+  const h = Math.floor(ms / 3600000);
+  const m = Math.floor((ms % 3600000) / 60000);
+  if (h > 0 && m > 0) return `${h}h ${m}m`;
+  if (h > 0) return `${h}h`;
+  if (m > 0) return `${m}m`;
+  return "< 1m";
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000)     return `${Math.round(n / 1_000)}k`;
+  return n.toString();
+}
+
+function changeBadge(current: number, prior: number | null): string | null {
+  if (prior === null || prior === 0) return null;
+  const pct = Math.round(((current - prior) / prior) * 100);
+  const arrow = pct >= 0 ? "▲" : "▼";
+  return `${arrow} ${Math.abs(pct)}% vs prior`;
+}
+
+// ── TUI Component ────────────────────────────────────────────────────
+
+type Row = { icon: string; label: string; value: string; badge?: string };
+
+function DigestApp({ period }: { period: DigestPeriod }) {
+  const [data, setData] = useState<DigestData | null>(null);
+
+  useEffect(() => {
+    setData(getDigest(period));
+  }, [period]);
+
+  if (!data) return <Text dimColor>Computing digest…</Text>;
+
+  if (data.sessions === 0 && data.totalTokens === 0) {
+    return (
+      <Box flexDirection="column">
+        <Text bold color="cyan">{data.rangeLabel}</Text>
+        <Text dimColor>No activity found for this period.</Text>
+        <Text>{""}</Text>
+      </Box>
+    );
+  }
+
+  const SEP = "────────────────────────────────────";
+
+  const rows: Row[] = [
+    { icon: "📅", label: "Active days",     value: `${data.activeDays} / ${data.totalDays}` },
+    {
+      icon: "💬", label: "Sessions",
+      value: String(data.sessions),
+      badge: changeBadge(data.sessions, data.priorSessions) ?? undefined,
+    },
+    { icon: "⏱ ", label: "Total time",      value: fmtMs(data.totalDurationMs) },
+    {
+      icon: "🔤", label: "Tokens used",
+      value: fmtTokens(data.totalTokens),
+      badge: changeBadge(data.totalTokens, data.priorTokens) ?? undefined,
+    },
+    ...(data.mostActiveRepo ? [{ icon: "🏆", label: "Most active repo", value: data.mostActiveRepo }] : []),
+    ...(data.peakHour       ? [{ icon: "🕐", label: "Peak hour",         value: data.peakHour }]       : []),
+    ...(data.topTool        ? [{
+      icon: "🔧", label: "Top tool",
+      value: data.topToolCalls > 0 ? `${data.topTool} (${data.topToolCalls} calls)` : data.topTool,
+    }] : []),
+    ...(data.topModel ? [{ icon: "🤖", label: "Top model", value: data.topModel }] : []),
+  ];
+
+  const labelW = Math.max(...rows.map((r) => r.label.length));
+
+  return (
+    <Box flexDirection="column">
+      <Text bold color="cyan">{data.rangeLabel}</Text>
+      <Text dimColor>{SEP}</Text>
+      {rows.map((row) => (
+        <Text key={row.label}>
+          <Text>{"  "}{row.icon}{"  "}</Text>
+          <Text dimColor>{row.label.padEnd(labelW)}</Text>
+          <Text>{"  "}{row.value}</Text>
+          {row.badge ? <Text dimColor>{"     "}{row.badge}</Text> : null}
+        </Text>
+      ))}
+      {data.longestSession && (
+        <Box marginTop={1}>
+          <Text dimColor>
+            {"  Longest session: "}
+            {data.longestSession.title
+              ? `"${data.longestSession.title.length > 40 ? data.longestSession.title.slice(0, 40) + "…" : data.longestSession.title}" — `
+              : ""}
+            {fmtMs(data.longestSession.durationMs)}
+            {data.longestSession.turns > 0 ? `, ${data.longestSession.turns} turns` : ""}
+          </Text>
+        </Box>
+      )}
+      <Newline />
+    </Box>
+  );
+}
+
+// ── Markdown export ──────────────────────────────────────────────────
+
+function toMarkdown(data: DigestData): string {
+  function change(cur: number, prior: number | null) {
+    const b = changeBadge(cur, prior);
+    return b ? ` _(${b})_` : "";
+  }
+
+  const lines = [
+    "# AI Usage Digest",
+    "",
+    `## ${data.rangeLabel}`,
+    "",
+    "| Metric | Value |",
+    "|--------|-------|",
+    `| Active days | ${data.activeDays} / ${data.totalDays} |`,
+    `| Sessions | ${data.sessions}${change(data.sessions, data.priorSessions)} |`,
+    `| Total time | ${fmtMs(data.totalDurationMs)} |`,
+    `| Tokens used | ${fmtTokens(data.totalTokens)}${change(data.totalTokens, data.priorTokens)} |`,
+  ];
+  if (data.mostActiveRepo) lines.push(`| Most active repo | ${data.mostActiveRepo} |`);
+  if (data.peakHour) lines.push(`| Peak hour | ${data.peakHour} |`);
+  if (data.topTool) {
+    const v = data.topToolCalls > 0 ? `${data.topTool} (${data.topToolCalls} calls)` : data.topTool;
+    lines.push(`| Top tool | ${v} |`);
+  }
+  if (data.topModel) lines.push(`| Top model | ${data.topModel} |`);
+
+  if (data.longestSession) {
+    const title = data.longestSession.title ?? "Untitled";
+    const dur = fmtMs(data.longestSession.durationMs);
+    const turns = data.longestSession.turns > 0 ? `, ${data.longestSession.turns} turns` : "";
+    lines.push("", "---", "", `**Longest session:** "${title}" — ${dur}${turns}`);
+  }
+
+  lines.push("", "---", "", "_Generated by copilot-lens_");
+  return lines.join("\n");
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────
+
+const HELP = `
+  Usage: copilot-lens digest [options]
+
+  Print a weekly usage summary to the terminal (Spotify Wrapped-style).
+
+  Options:
+    --last-week   Show last week instead of the current week
+    --month       Show the current month's digest
+    --save        Also write digest.md to the current directory
+    --json        Output raw JSON (pipeline-friendly)
+    -h, --help    Show this help
+`.trimStart();
+
+export function parseDigestArgs(argv: string[]): {
+  period: DigestPeriod;
+  save: boolean;
+  json: boolean;
+  help: boolean;
+} {
+  let period: DigestPeriod = "week";
+  let save = false;
+  let json = false;
+  let help = false;
+
+  for (const a of argv) {
+    if (a === "--last-week") period = "last-week";
+    else if (a === "--month") period = "month";
+    else if (a === "--save") save = true;
+    else if (a === "--json") json = true;
+    else if (a === "--help" || a === "-h") help = true;
+  }
+
+  return { period, save, json, help };
+}
+
+export function runDigestTUI(argv: string[]): void {
+  const opts = parseDigestArgs(argv);
+
+  if (opts.help) {
+    process.stdout.write(HELP);
+    return;
+  }
+
+  if (opts.json) {
+    const data = getDigest(opts.period);
+    process.stdout.write(JSON.stringify(data, null, 2) + "\n");
+    return;
+  }
+
+  if (opts.save) {
+    const data = getDigest(opts.period);
+    const md = toMarkdown(data);
+    const outPath = path.join(process.cwd(), "digest.md");
+    fs.writeFileSync(outPath, md, "utf-8");
+    process.stderr.write(`Saved digest to ${outPath}\n`);
+  }
+
+  render(<DigestApp period={opts.period} />);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,6 +12,9 @@ const args = process.argv.slice(2);
 if (args[0] === "tokens") {
   const { runTokensTUI } = require("./cli-tokens");
   runTokensTUI(args.slice(1));
+} else if (args[0] === "digest") {
+  const { runDigestTUI } = require("./cli-digest");
+  runDigestTUI(args.slice(1));
 } else if (args[0] === "--help" || args[0] === "-h" || args[0] === "help") {
   process.stdout.write(`
   Usage: copilot-lens [command] [options]
@@ -19,6 +22,7 @@ if (args[0] === "tokens") {
   Commands:
     (default)   Start the web dashboard
     tokens      Show token usage in the terminal (Ink TUI)
+    digest      Show a period-based usage summary in the terminal
 
   Options:
     --port <n>  Port for the web dashboard (default: 3000)
@@ -26,6 +30,7 @@ if (args[0] === "tokens") {
     --open      Open the dashboard in your browser
 
   Run "copilot-lens tokens --help" for tokens command options.
+  Run "copilot-lens digest --help" for digest command options.
 `);
 } else {
   const { createApp } = require("./server");

--- a/src/digest.ts
+++ b/src/digest.ts
@@ -121,7 +121,7 @@ export function getDigest(period: DigestPeriod = "week"): DigestData {
           const readSize = Math.min(stat.size, 1024 * 1024);
           const buf = Buffer.alloc(readSize);
           const fd = fs.openSync(evPath, "r");
-          fs.readSync(fd, buf, 0, readSize, 0);
+          fs.readSync(fd, buf, 0, readSize, Math.max(0, stat.size - readSize));
           fs.closeSync(fd);
           const tsList: number[] = [];
 
@@ -201,8 +201,6 @@ export function getDigest(period: DigestPeriod = "week"): DigestData {
   let topModel: string | null = null;
   if (Object.keys(modelTokens).length > 0) {
     topModel = Object.entries(modelTokens).sort((a, b) => b[1] - a[1])[0][0];
-  } else if (tokenData.totals.top_model) {
-    topModel = tokenData.totals.top_model;
   }
 
   return {

--- a/src/digest.ts
+++ b/src/digest.ts
@@ -1,0 +1,226 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { listSessions } from "./sessions";
+import { getTokenUsage } from "./token-usage";
+
+export type DigestPeriod = "week" | "last-week" | "month";
+
+export interface DigestData {
+  rangeLabel: string;
+  startDate: string;
+  endDate: string;
+  activeDays: number;
+  totalDays: number;
+  sessions: number;
+  totalDurationMs: number;
+  totalTokens: number;
+  mostActiveRepo: string | null;
+  peakHour: string | null;
+  topTool: string | null;
+  topToolCalls: number;
+  topModel: string | null;
+  longestSession: {
+    title: string | null;
+    durationMs: number;
+    turns: number;
+  } | null;
+  priorSessions: number;
+  priorTokens: number | null;
+}
+
+function isoDay(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function weekBounds(offset = 0): { start: Date; end: Date; label: string } {
+  const now = new Date();
+  const dow = now.getUTCDay(); // 0=Sun
+  const toMonday = dow === 0 ? 6 : dow - 1;
+  const mon = new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - toMonday - offset * 7)
+  );
+  const sun = new Date(mon);
+  sun.setUTCDate(mon.getUTCDate() + 6);
+  const end = new Date(sun);
+  end.setUTCHours(23, 59, 59, 999);
+
+  const M = ["Jan","Feb","Mar","Apr","May","Jun","Jul","Aug","Sep","Oct","Nov","Dec"];
+  const label = `Week of ${M[mon.getUTCMonth()]} ${mon.getUTCDate()} – ${M[sun.getUTCMonth()]} ${sun.getUTCDate()}, ${sun.getUTCFullYear()}`;
+  return { start: mon, end, label };
+}
+
+function monthBounds(offset = 0): { start: Date; end: Date; label: string } {
+  const now = new Date();
+  const d = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - offset, 1));
+  const start = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1));
+  const end = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 0, 23, 59, 59, 999));
+  const M = ["January","February","March","April","May","June","July","August","September","October","November","December"];
+  return { start, end, label: `${M[d.getUTCMonth()]} ${d.getUTCFullYear()}` };
+}
+
+function getBounds(period: DigestPeriod) {
+  if (period === "week")      return { cur: weekBounds(0),  prior: weekBounds(1) };
+  if (period === "last-week") return { cur: weekBounds(1),  prior: weekBounds(2) };
+  return                             { cur: monthBounds(0), prior: monthBounds(1) };
+}
+
+function fmtHour(h: number): string {
+  if (h === 0)  return "12 – 1 AM";
+  if (h < 12)   return `${h} – ${h + 1} AM`;
+  if (h === 12) return "12 – 1 PM";
+  return `${h - 12} – ${h - 11} PM`;
+}
+
+function getSessionDir(): string {
+  return path.join(os.homedir(), ".copilot", "session-state");
+}
+
+export function getDigest(period: DigestPeriod = "week"): DigestData {
+  const { cur, prior } = getBounds(period);
+  const allSessions = listSessions();
+
+  const inRange = allSessions.filter((s) => {
+    const t = new Date(s.createdAt).getTime();
+    return t >= cur.start.getTime() && t <= cur.end.getTime();
+  });
+  const inPrior = allSessions.filter((s) => {
+    const t = new Date(s.createdAt).getTime();
+    return t >= prior.start.getTime() && t <= prior.end.getTime();
+  });
+
+  const activeDays = new Set(inRange.map((s) => s.createdAt.slice(0, 10)).filter(Boolean)).size;
+  const totalDays = Math.round((cur.end.getTime() - cur.start.getTime()) / 86400000) + 1;
+
+  const repoCount: Record<string, number> = {};
+  const hourCount: Record<number, number> = {};
+  const toolCount: Record<string, number> = {};
+  let totalDurationMs = 0;
+  let longestSession: DigestData["longestSession"] = null;
+
+  const sDir = getSessionDir();
+
+  for (const s of inRange) {
+    const hour = new Date(s.createdAt).getHours();
+    hourCount[hour] = (hourCount[hour] || 0) + 1;
+
+    const repo = s.gitRoot || s.cwd;
+    if (repo) repoCount[repo] = (repoCount[repo] || 0) + 1;
+
+    const created = new Date(s.createdAt).getTime();
+    const updatedRaw = new Date(s.updatedAt).getTime();
+    const updated = isNaN(updatedRaw) ? created : updatedRaw;
+    let dur = Math.min(Math.max(updated - created, 0), 4 * 3600_000);
+    let turns = 0;
+
+    if (s.source === "cli") {
+      const evPath = path.join(sDir, s.id, "events.jsonl");
+      try {
+        if (fs.existsSync(evPath)) {
+          const stat = fs.statSync(evPath);
+          const readSize = Math.min(stat.size, 1024 * 1024);
+          const buf = Buffer.alloc(readSize);
+          const fd = fs.openSync(evPath, "r");
+          fs.readSync(fd, buf, 0, readSize, 0);
+          fs.closeSync(fd);
+          const tsList: number[] = [];
+
+          for (const line of buf.toString("utf-8").split("\n")) {
+            if (!line.trim()) continue;
+            try {
+              const ev = JSON.parse(line);
+              if (ev.timestamp) {
+                const t = new Date(ev.timestamp).getTime();
+                if (t > 0) tsList.push(t);
+              }
+              if (ev.type === "tool.execution_start") {
+                const tool: string = ev.data?.tool || ev.data?.toolName || "";
+                if (tool) toolCount[tool] = (toolCount[tool] || 0) + 1;
+              }
+              if (ev.type === "assistant.turn_start") turns++;
+            } catch { /* skip malformed lines */ }
+          }
+
+          if (tsList.length >= 2) {
+            tsList.sort((a, b) => a - b);
+            let evDur = 0;
+            for (let i = 1; i < tsList.length; i++) {
+              evDur += Math.min(tsList[i] - tsList[i - 1], 300_000);
+            }
+            if (evDur > 0) dur = evDur;
+          }
+        }
+      } catch { /* skip unreadable sessions */ }
+    }
+
+    totalDurationMs += dur;
+
+    const title = s.title ?? (repo ? path.basename(repo) : null);
+    if (!longestSession || dur > longestSession.durationMs) {
+      longestSession = { title, durationMs: dur, turns };
+    }
+  }
+
+  // Token data: filter daily buckets by date range
+  const tokenData = getTokenUsage("all");
+  let totalTokens = 0;
+  let priorTokens = 0;
+  const modelTokens: Record<string, number> = {};
+
+  for (const day of tokenData.daily) {
+    const t = new Date(day.period + "T00:00:00Z").getTime();
+    if (t >= cur.start.getTime() && t <= cur.end.getTime()) {
+      totalTokens += day.total_tokens;
+      for (const [m, stats] of Object.entries(day.models)) {
+        modelTokens[m] = (modelTokens[m] || 0) + stats.total_tokens;
+      }
+    }
+    if (t >= prior.start.getTime() && t <= prior.end.getTime()) {
+      priorTokens += day.total_tokens;
+    }
+  }
+
+  const mostActiveRepo =
+    Object.keys(repoCount).length > 0
+      ? path.basename(Object.entries(repoCount).sort((a, b) => b[1] - a[1])[0][0])
+      : null;
+
+  const peakHour =
+    Object.keys(hourCount).length > 0
+      ? fmtHour(parseInt(Object.entries(hourCount).sort((a, b) => b[1] - a[1])[0][0]))
+      : null;
+
+  let topTool: string | null = null;
+  let topToolCalls = 0;
+  if (Object.keys(toolCount).length > 0) {
+    const [name, count] = Object.entries(toolCount).sort((a, b) => b[1] - a[1])[0];
+    topTool = name.charAt(0).toUpperCase() + name.slice(1);
+    topToolCalls = count;
+  }
+
+  let topModel: string | null = null;
+  if (Object.keys(modelTokens).length > 0) {
+    topModel = Object.entries(modelTokens).sort((a, b) => b[1] - a[1])[0][0];
+  } else if (tokenData.totals.top_model) {
+    topModel = tokenData.totals.top_model;
+  }
+
+  return {
+    rangeLabel: cur.label,
+    startDate: isoDay(cur.start),
+    endDate: isoDay(cur.end),
+    activeDays,
+    totalDays,
+    sessions: inRange.length,
+    totalDurationMs,
+    totalTokens,
+    mostActiveRepo,
+    peakHour,
+    topTool,
+    topToolCalls,
+    topModel,
+    longestSession: longestSession && longestSession.durationMs > 0 ? longestSession : null,
+    priorSessions: inPrior.length,
+    priorTokens: priorTokens > 0 ? priorTokens : null,
+  };
+}

--- a/src/digest.ts
+++ b/src/digest.ts
@@ -90,7 +90,7 @@ export function getDigest(period: DigestPeriod = "week"): DigestData {
   });
 
   const activeDays = new Set(inRange.map((s) => s.createdAt.slice(0, 10)).filter(Boolean)).size;
-  const totalDays = Math.round((cur.end.getTime() - cur.start.getTime()) / 86400000) + 1;
+  const totalDays = Math.round((cur.end.getTime() - cur.start.getTime()) / 86400000);
 
   const repoCount: Record<string, number> = {};
   const hourCount: Record<number, number> = {};


### PR DESCRIPTION
## Summary

Implements the `copilot-lens digest` command from issue #70 — a Spotify Wrapped-style terminal summary of AI usage.

```
copilot-lens digest               # current week (default)
copilot-lens digest --last-week   # prior week
copilot-lens digest --month       # current month
copilot-lens digest --save        # also writes digest.md to cwd
copilot-lens digest --json        # machine-readable JSON
```

**Sample output:**
```
Week of Jun 2 – Jun 8, 2026
────────────────────────────────────
  📅  Active days       5 / 7
  💬  Sessions          34     ▲ 12% vs prior
  ⏱   Total time        6h 14m
  🔤  Tokens used       1.2M   ▲ 8% vs prior
  🏆  Most active repo  copilot-lens
  🕐  Peak hour         2 – 3 PM
  🔧  Top tool          Bash (41 calls)
  🤖  Top model         claude-sonnet-4-6

  Longest session: "copilot-lens" — 48m, 23 turns
```

## Changes

- **`src/digest.ts`** — `getDigest(period)` aggregates sessions from `listSessions()` filtered by date range; scans CLI event files for tool usage, accurate duration, and turn counts; pulls token totals from `getTokenUsage().daily` buckets filtered to the range. No new data sources.
- **`src/cli-digest.tsx`** — Ink TUI mirroring `cli-tokens.tsx` style; `--save` writes `digest.md`; `--json` outputs raw JSON for piping.
- **`src/cli.ts`** — wires `digest` subcommand and updates help text.
- **`src/__tests__/cli-digest.test.ts`** — 8 tests covering all `parseDigestArgs` combinations.

## Test plan

- [ ] `copilot-lens digest` renders the weekly summary
- [ ] `copilot-lens digest --last-week` shows prior week label
- [ ] `copilot-lens digest --month` shows current month label
- [ ] `copilot-lens digest --json` outputs valid JSON with all fields
- [ ] `copilot-lens digest --save` writes `digest.md` and also renders TUI
- [ ] `copilot-lens digest --help` shows usage text
- [ ] No activity period shows "No activity found for this period."
- [ ] All 122 unit tests pass

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)