### PR TITLE
fix: validate --port and add CLI tests

### DIFF
--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -2,8 +2,11 @@
  * Parsed options for the dashboard entrypoint.
  */
 export interface DashboardArgs {
+  /** Hostname or interface to bind the dashboard server to. */
   host: string;
+  /** TCP port to listen on. */
   port: number;
+  /** Whether the CLI should open the dashboard URL in the default browser. */
   shouldOpen: boolean;
 }
 

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,3 +1,6 @@
+/**
+ * Parsed options for the dashboard entrypoint.
+ */
 export interface DashboardArgs {
   host: string;
   port: number;
@@ -9,6 +12,13 @@ function getArg(args: string[], name: string, fallback: string): string {
   return idx !== -1 && args[idx + 1] ? args[idx + 1] : fallback;
 }
 
+/**
+ * Parse dashboard CLI flags and validate the optional port override.
+ *
+ * @param args Raw dashboard CLI arguments without the node executable prefix.
+ * @returns Parsed dashboard host, port, and browser-open flag.
+ * @throws {Error} When `--port` is missing a valid integer in the 1-65535 range.
+ */
 export function parseDashboardArgs(args: string[]): DashboardArgs {
   const rawPort = getArg(args, "--port", "3000");
   if (!/^\d+$/.test(rawPort)) {

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,0 +1,28 @@
+export interface DashboardArgs {
+  host: string;
+  port: number;
+  shouldOpen: boolean;
+}
+
+function getArg(args: string[], name: string, fallback: string): string {
+  const idx = args.indexOf(name);
+  return idx !== -1 && args[idx + 1] ? args[idx + 1] : fallback;
+}
+
+export function parseDashboardArgs(args: string[]): DashboardArgs {
+  const rawPort = getArg(args, "--port", "3000");
+  if (!/^\d+$/.test(rawPort)) {
+    throw new Error(`Error: --port must be a number between 1 and 65535. Got: "${rawPort}"`);
+  }
+
+  const port = Number.parseInt(rawPort, 10);
+  if (port < 1 || port > 65535) {
+    throw new Error(`Error: --port must be a number between 1 and 65535. Got: "${rawPort}"`);
+  }
+
+  return {
+    port,
+    host: getArg(args, "--host", "localhost"),
+    shouldOpen: args.includes("--open"),
+  };
+}

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { parseDashboardArgs } from "./cli-args";
+
+describe("parseDashboardArgs", () => {
+  it("accepts a normal port", () => {
+    expect(parseDashboardArgs(["--port", "3000"])).toMatchObject({
+      port: 3000,
+      host: "localhost",
+      shouldOpen: false,
+    });
+  });
+
+  it("accepts the minimum and maximum valid ports", () => {
+    expect(parseDashboardArgs(["--port", "1"]).port).toBe(1);
+    expect(parseDashboardArgs(["--port", "65535"]).port).toBe(65535);
+  });
+
+  it("rejects a port below the valid range", () => {
+    expect(() => parseDashboardArgs(["--port", "0"])).toThrow(
+      'Error: --port must be a number between 1 and 65535. Got: "0"'
+    );
+  });
+
+  it("rejects a port above the valid range", () => {
+    expect(() => parseDashboardArgs(["--port", "99999"])).toThrow(
+      'Error: --port must be a number between 1 and 65535. Got: "99999"'
+    );
+  });
+
+  it("rejects a non-numeric port", () => {
+    expect(() => parseDashboardArgs(["--port", "abc"])).toThrow(
+      'Error: --port must be a number between 1 and 65535. Got: "abc"'
+    );
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,15 +29,17 @@ if (args[0] === "tokens") {
 `);
 } else {
   const { createApp } = require("./server");
+  const { parseDashboardArgs } = require("./cli-args");
+  let host: string;
+  let port: number;
+  let shouldOpen: boolean;
 
-  function getArg(name: string, fallback: string): string {
-    const idx = args.indexOf(name);
-    return idx !== -1 && args[idx + 1] ? args[idx + 1] : fallback;
+  try {
+    ({ host, port, shouldOpen } = parseDashboardArgs(args));
+  } catch (error: any) {
+    console.error(error.message);
+    process.exit(1);
   }
-
-  const port = parseInt(getArg("--port", "3000"), 10);
-  const host = getArg("--host", "localhost");
-  const shouldOpen = args.includes("--open");
 
   const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
   if (!LOOPBACK_HOSTS.has(host)) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-process.on("uncaughtException", (err) => {
-  console.error("Uncaught error:", err.message);
+process.on("uncaughtException", (error: unknown) => {
+  console.error("Uncaught error:", formatErrorMessage(error));
 });
 process.on("unhandledRejection", (err: unknown) => {
   console.error("Unhandled rejection:", formatErrorMessage(err));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,8 +3,8 @@
 process.on("uncaughtException", (err) => {
   console.error("Uncaught error:", err.message);
 });
-process.on("unhandledRejection", (err: any) => {
-  console.error("Unhandled rejection:", err?.message || err);
+process.on("unhandledRejection", (err: unknown) => {
+  console.error("Unhandled rejection:", formatErrorMessage(err));
 });
 
 function formatErrorMessage(error: unknown): string {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,6 +7,10 @@ process.on("unhandledRejection", (err: any) => {
   console.error("Unhandled rejection:", err?.message || err);
 });
 
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 const args = process.argv.slice(2);
 
 if (args[0] === "tokens") {
@@ -36,8 +40,8 @@ if (args[0] === "tokens") {
 
   try {
     ({ host, port, shouldOpen } = parseDashboardArgs(args));
-  } catch (error: any) {
-    console.error(error.message);
+  } catch (error: unknown) {
+    console.error(formatErrorMessage(error));
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- validate `--port` before starting the dashboard so invalid values fail with a clear error
- move dashboard argument parsing into a small helper so the validation can be tested directly
- add CLI tests covering valid, out-of-range, and non-numeric ports

Closes #90
Closes #117

## Validation
- `npm test`
- `npm run build`
