### PR TITLE
chore: add npm run typecheck command

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "node dist/cli.js",
     "test": "vitest run",
     "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },
   "keywords": [


### PR DESCRIPTION
## Summary

Closes #54 — adds a `typecheck` npm script to `package.json`.

## Changes

### 1. `package.json`
- Added `"typecheck": "tsc --noEmit"` to the `"scripts"` field.
