### PR TITLE
Fix path traversal, CORS exposure, shell injection, and stale search index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "copilot-lens",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "copilot-lens",
-      "version": "1.2.1",
+      "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.6.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "better-sqlite3": "^12.6.2",
-        "cors": "^2.8.6",
         "express": "^5.2.1",
         "ink": "^3.2.0",
         "react": "^17.0.2",
@@ -21,7 +20,6 @@
       },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
-        "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "@types/node": "^25.2.2",
         "@types/react": "^17.0.91",
@@ -878,16 +876,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/cors": {
-      "version": "2.8.19",
-      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
-      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -1512,23 +1500,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
-      }
-    },
-    "node_modules/cors": {
-      "version": "2.8.6",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
-      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
-      "license": "MIT",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/csstype": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "copilot-lens",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A local dashboard to visualize and analyze your GitHub Copilot CLI sessions",
   "main": "dist/server.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   ],
   "dependencies": {
     "better-sqlite3": "^12.6.2",
-    "cors": "^2.8.6",
     "express": "^5.2.1",
     "ink": "^3.2.0",
     "react": "^17.0.2",
@@ -43,7 +42,6 @@
   },
   "devDependencies": {
     "@types/better-sqlite3": "^7.6.13",
-    "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/node": "^25.2.2",
     "@types/react": "^17.0.91",

--- a/src/__tests__/search.test.ts
+++ b/src/__tests__/search.test.ts
@@ -230,6 +230,47 @@ describe("SearchIndex.clear()", () => {
   });
 });
 
+// ─── Test 9b: rebuild when the session set changes ──────────────────────────
+
+describe("SearchIndex.buildIndex — staleness", () => {
+  it("reflects a newly added session on the next search without an explicit clear", () => {
+    const index = new SearchIndex();
+    const first = makeMeta({ id: "sess-a", title: "first", updatedAt: "2024-01-15T11:00:00Z" });
+
+    mockGetSession.mockImplementation((id) =>
+      id === "sess-a"
+        ? makeDetail(first, [{ type: "user.message", content: "apple pie recipe" }])
+        : makeDetail(makeMeta({ id: "sess-b", title: "second", updatedAt: "2024-01-16T11:00:00Z" }), [
+            { type: "user.message", content: "mango smoothie recipe" },
+          ])
+    );
+
+    index.buildIndex([first]);
+    expect(index.search("apple")).toHaveLength(1);
+    expect(index.search("mango")).toHaveLength(0);
+
+    // A new session appears (different count + later updatedAt) — the index
+    // must rebuild even though it was already populated.
+    const second = makeMeta({ id: "sess-b", title: "second", updatedAt: "2024-01-16T11:00:00Z" });
+    index.buildIndex([first, second]);
+    expect(index.search("mango")).toHaveLength(1);
+    expect(index.search("apple")).toHaveLength(1);
+  });
+
+  it("does not rebuild when the session set is unchanged", () => {
+    const index = new SearchIndex();
+    const meta = makeMeta({ id: "sess-a" });
+    mockGetSession.mockReturnValue(
+      makeDetail(meta, [{ type: "user.message", content: "stable content" }])
+    );
+
+    index.buildIndex([meta]);
+    const callsAfterFirst = mockGetSession.mock.calls.length;
+    index.buildIndex([meta]); // same signature → no-op
+    expect(mockGetSession.mock.calls.length).toBe(callsAfterFirst);
+  });
+});
+
 // ─── Test 10: limit option ───────────────────────────────────────────────────
 
 describe("SearchIndex.search — limit option", () => {

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { isValidSessionId } from "../validation";
+
+describe("isValidSessionId", () => {
+  it("accepts UUID-like ids", () => {
+    expect(isValidSessionId("9f1c2e3a-1234-4abc-9def-0123456789ab")).toBe(true);
+    expect(isValidSessionId("sess-001")).toBe(true);
+    expect(isValidSessionId("abc_DEF.123")).toBe(true);
+  });
+
+  it("rejects path-traversal sequences", () => {
+    expect(isValidSessionId("..")).toBe(false);
+    expect(isValidSessionId("../../etc/passwd")).toBe(false);
+    expect(isValidSessionId("..%2f..%2fetc")).toBe(false);
+    expect(isValidSessionId("foo/../bar")).toBe(false);
+  });
+
+  it("rejects path separators", () => {
+    expect(isValidSessionId("foo/bar")).toBe(false);
+    expect(isValidSessionId("foo\\bar")).toBe(false);
+    expect(isValidSessionId("/etc/hosts")).toBe(false);
+  });
+
+  it("rejects empty, oversized, and non-string input", () => {
+    expect(isValidSessionId("")).toBe(false);
+    expect(isValidSessionId("a".repeat(257))).toBe(false);
+    expect(isValidSessionId(undefined)).toBe(false);
+    expect(isValidSessionId(null)).toBe(false);
+    expect(isValidSessionId(42)).toBe(false);
+  });
+});

--- a/src/claude-code-sessions.ts
+++ b/src/claude-code-sessions.ts
@@ -4,6 +4,7 @@ import * as os from "os";
 import { randomUUID } from "crypto";
 import type { SessionMeta, SessionDetail, SessionEvent, SessionStatus } from "./sessions";
 import { cachedCall } from "./cache";
+import { isValidSessionId } from "./validation";
 
 // ============ Platform paths ============
 
@@ -196,6 +197,7 @@ export function listClaudeCodeSessions(): SessionMeta[] {
 
 /** Find the JSONL file for a given session ID by scanning projects dir */
 function findSessionFile(sessionId: string): string | null {
+  if (!isValidSessionId(sessionId)) return null;
   const projectsDir = getClaudeCodeProjectsDir();
   if (!fs.existsSync(projectsDir)) return null;
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -39,21 +39,30 @@ if (args[0] === "tokens") {
   const host = getArg("--host", "localhost");
   const shouldOpen = args.includes("--open");
 
-  const app = createApp();
+  const LOOPBACK_HOSTS = new Set(["localhost", "127.0.0.1", "::1"]);
+  if (!LOOPBACK_HOSTS.has(host)) {
+    console.warn(
+      `\n  ⚠️  Binding to ${host} exposes your AI session data to the network with no authentication.\n`
+    );
+  }
+
+  const app = createApp({ host });
 
   app.listen(port, host, async () => {
     const url = `http://${host}:${port}`;
     console.log(`\n  👓 Copilot Lens is running at ${url}\n`);
 
     if (shouldOpen) {
-      const { exec } = await import("child_process");
-      const cmd =
-        process.platform === "win32"
-          ? `start "" "${url}"`
-          : process.platform === "darwin"
-            ? `open ${url}`
-            : `xdg-open ${url}`;
-      exec(cmd);
+      // Use execFile with an argument array (no shell) so the URL/host cannot
+      // be interpreted as shell syntax.
+      const { execFile } = await import("child_process");
+      if (process.platform === "win32") {
+        execFile("cmd", ["/c", "start", "", url]);
+      } else if (process.platform === "darwin") {
+        execFile("open", [url]);
+      } else {
+        execFile("xdg-open", [url]);
+      }
     }
   });
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -51,12 +51,25 @@ function trimToWordBoundary(text: string, start: number, end: number): string {
 export class SearchIndex {
   private entries: SearchEntry[] = [];
   private storedSessions: SessionMeta[] | null = null;
+  private signature = "";
+
+  // A cheap fingerprint of the session set. Changes when sessions are added,
+  // removed, or updated, so the index can detect when it has gone stale.
+  private computeSignature(sessions: SessionMeta[]): string {
+    let latest = "";
+    for (const s of sessions) {
+      if (s.updatedAt > latest) latest = s.updatedAt;
+    }
+    return `${sessions.length}:${latest}`;
+  }
 
   buildIndex(sessions: SessionMeta[]): void {
     // Store sessions for lazy rebuild after clear()
     this.storedSessions = sessions;
-    // No-op if already built
-    if (this.entries.length > 0) return;
+    // No-op only if already built AND the session set is unchanged
+    const sig = this.computeSignature(sessions);
+    if (this.entries.length > 0 && sig === this.signature) return;
+    this.signature = sig;
     this._doBuild(sessions);
   }
 
@@ -100,7 +113,7 @@ export class SearchIndex {
     // Lazy build: only build if entries is empty
     if (this.entries.length === 0) {
       if (this.storedSessions) {
-        this._doBuild(this.storedSessions);
+        this.buildIndex(this.storedSessions);
       } else {
         return [];
       }
@@ -203,6 +216,7 @@ export class SearchIndex {
 
   clear(): void {
     this.entries = [];
+    this.signature = "";
     // storedSessions kept so search() can lazy-rebuild after clear()
   }
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,14 +1,48 @@
 import express from "express";
-import cors from "cors";
 import path from "path";
 import { listSessions, getSession, getAnalytics, listReposWithScores, getRepoScore, getVSCodeScore, type AnalyticsSourceFilter } from "./sessions";
 import { clearCache } from "./cache";
 import { SearchIndex } from "./search";
 import { getTokenUsage, type TokenSourceFilter } from "./token-usage";
 
-export function createApp() {
+export interface AppOptions {
+  // The host the server binds to. Used to build the allowed-Host list so a
+  // concrete LAN binding still works while loopback stays rebinding-protected.
+  host?: string;
+}
+
+const WILDCARD_HOSTS = new Set(["0.0.0.0", "::", "[::]"]);
+
+// Guards against DNS-rebinding: a malicious page that points its own domain at
+// 127.0.0.1 sends a Host header for that domain, which we reject. The dashboard
+// is same-origin so no CORS is needed; cross-origin reads stay blocked entirely.
+function hostGuard(configuredHost?: string): express.RequestHandler {
+  const host = (configuredHost || "").toLowerCase();
+
+  // When bound to a wildcard interface the user has explicitly opted into
+  // network exposure and we can't enumerate the reachable IPs, so skip the
+  // guard rather than break legitimate access (a startup warning is printed).
+  if (WILDCARD_HOSTS.has(host)) {
+    return (_req, _res, next) => next();
+  }
+
+  const allowed = new Set(["localhost", "127.0.0.1", "::1", "[::1]"]);
+  if (host) allowed.add(host);
+
+  return (req, res, next) => {
+    const header = (req.headers.host || "").toLowerCase();
+    const hostname = header.replace(/:\d+$/, ""); // strip port (keeps [::1])
+    if (!allowed.has(hostname)) {
+      res.status(403).json({ error: "Forbidden: invalid Host header" });
+      return;
+    }
+    next();
+  };
+}
+
+export function createApp(options: AppOptions = {}) {
   const app = express();
-  app.use(cors());
+  app.use(hostGuard(options.host));
 
   const searchIndex = new SearchIndex();
 

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -5,6 +5,7 @@ import { parse as parseYaml } from "yaml";
 import { listVSCodeSessions, getVSCodeSession, isVSCodeSession, getVSCodeAnalytics, normalizeVSCodeToolName, scanVSCodeMcpConfig } from "./vscode-sessions";
 import { listClaudeCodeSessions, getClaudeCodeSession, isClaudeCodeSession, getClaudeCodeAnalytics } from "./claude-code-sessions";
 import { cachedCall } from "./cache";
+import { isValidSessionId } from "./validation";
 
 export type SessionStatus = "running" | "completed" | "error";
 export type SessionSource = "cli" | "vscode" | "claude-code";
@@ -184,6 +185,9 @@ export function listSessions(): SessionMeta[] {
 }
 
 export function getSession(sessionId: string): SessionDetail | null {
+  // Reject ids that could traverse outside the session directories.
+  if (!isValidSessionId(sessionId)) return null;
+
   // Check VS Code sessions first (avoids filesystem miss for CLI)
   try {
     if (isVSCodeSession(sessionId)) {

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,18 @@
+// Validation helpers for untrusted input that reaches the filesystem.
+
+// Session IDs are UUID-like tokens (CLI directory names, VS Code session ids,
+// Claude Code filename stems) that get interpolated into filesystem paths. An
+// attacker-controlled id such as "../../etc/passwd" would otherwise allow
+// directory traversal, so we restrict ids to a conservative character set with
+// no path separators and reject any ".." traversal sequence.
+const SESSION_ID_RE = /^[A-Za-z0-9._-]+$/;
+
+export function isValidSessionId(id: unknown): id is string {
+  return (
+    typeof id === "string" &&
+    id.length > 0 &&
+    id.length <= 256 &&
+    !id.includes("..") &&
+    SESSION_ID_RE.test(id)
+  );
+}

--- a/src/vscode-sessions.ts
+++ b/src/vscode-sessions.ts
@@ -5,6 +5,7 @@ import { randomUUID } from "crypto";
 import Database from "better-sqlite3";
 import type { SessionMeta, SessionDetail, SessionEvent, SessionStatus } from "./sessions";
 import { cachedCall } from "./cache";
+import { isValidSessionId } from "./validation";
 
 // ============ Platform paths ============
 
@@ -64,6 +65,7 @@ const MAX_FILE_SIZE = 200 * 1024 * 1024; // 200MB cap
 const MAX_TEXT_LENGTH = 10_000; // truncate huge pasted text
 
 function findSessionFile(dataDir: string, sessionId: string): string | null {
+  if (!isValidSessionId(sessionId)) return null;
   const paths = [
     path.join(dataDir, "User", "globalStorage", "emptyWindowChatSessions", `${sessionId}.json`),
   ];


### PR DESCRIPTION
Fixes #154, #155, #156, #157 in one pass.

## Security

### #154 — Path traversal via session `:id`
The `:id` route param was interpolated into filesystem paths in all three parsers, allowing traversal to arbitrary `.json`/`.jsonl` files. Added `isValidSessionId()` (`src/validation.ts`) — a conservative allowlist (`[A-Za-z0-9._-]`, no `..`, length-bounded) — and applied it in `getSession()` and both `findSessionFile()` helpers.

### #155 — Wildcard CORS + network exposure
- Removed `app.use(cors())`. The dashboard is same-origin, so no CORS header is needed and cross-origin reads are now blocked by default.
- Added a **Host-header guard** that rejects requests whose Host isn't loopback (or the explicitly configured host), defeating DNS-rebinding attacks against the default localhost bind.
- Binding to a non-loopback/wildcard host now prints a security warning; the guard steps aside there since the user explicitly opted into network exposure.
- Dropped the now-unused `cors` / `@types/cors` dependencies.

### #156 — Shell injection in `--open`
Replaced `exec()` (shell string) with `execFile()` (argument array), so the host/url can no longer be interpreted as shell syntax.

## Correctness

### #157 — Stale search index
`buildIndex()` no-opped once populated, so new/updated sessions never appeared in search until the cache was cleared. It now tracks a cheap signature (session count + latest `updatedAt`) and rebuilds when the set changes. `clear()` resets the signature; lazy rebuild routes through `buildIndex()` so the signature stays in sync.

## Tests
- New `src/__tests__/validation.test.ts` covering id validation (traversal, separators, bounds, non-string).
- New staleness cases in `search.test.ts` (new session appears without an explicit clear; unchanged set does not rebuild).
- Full suite: **120 passing**; `tsc` build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)