### PR TITLE
feat: show 'No results' message when search returns zero sessions

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -869,12 +869,14 @@ function clearSearch() {
 }
 
 function renderSearchResults(results) {
+  const query = searchInput.value.trim();
   if (!results || results.length === 0) {
     sessionCount.textContent = "No results found";
     sessionList.innerHTML = `
       <div class="empty-state">
         <span class="empty-icon">🔍</span>
-        <p>No results found for your search</p>
+        <p>No sessions matched "<strong>${escapeHtml(query)}</strong>".</p>
+        <p class="empty-state-hint">Try using broader search terms or clearing filters.</p>
       </div>`;
     return;
   }

--- a/public/app.js
+++ b/public/app.js
@@ -875,7 +875,7 @@ function renderSearchResults(results) {
     sessionList.innerHTML = `
       <div class="empty-state">
         <span class="empty-icon">🔍</span>
-        <p>No sessions matched "<strong>${escapeHtml(query)}</strong>".</p>
+        <p>${query ? `No sessions matched "<strong>${escapeHtml(query)}</strong>".` : "No sessions found."}</p>
         <p class="empty-state-hint">Try using broader search terms or clearing filters.</p>
       </div>`;
     return;

--- a/public/style.css
+++ b/public/style.css
@@ -775,7 +775,7 @@ select:focus { box-shadow: 0 0 0 3px rgba(88,166,255,0.15); }
 
 .empty-state-hint {
   font-size: 0.85em;
-  color: var(--text-muted);
+  color: var(--text-dim);
 }
 
 .error-message {


### PR DESCRIPTION
## Summary

Closes #111 — Shows a clearer "No results found" message that incorporates the user's search query, and fixes a CSS color reference for empty state hints.

## Visual Comparison (Before & After)

| Before | After |
|---|---|
| <img src="https://github.com/user-attachments/assets/c9f45a44-3502-49a6-b1f3-e65cc9b3ac21" width="600" /> | <img src="https://github.com/user-attachments/assets/e1a796a3-ee9b-4ada-bf76-d5e9959ad62b" width="600" /> |

---

## What Changed

### `public/app.js`
- Updated `renderSearchResults()` to retrieve the search input query.
- Modified the empty state innerHTML string to dynamically embed the escaped search query in a bold tag.
- Added a helpful hint paragraph: "Try using broader search terms or clearing filters."

### `public/style.css`
- Corrected the `.empty-state-hint` class text color property from `var(--text-muted)` (which was undefined in the CSS variables block) to `var(--text-dim)`.

## Verification Results

Verified the changes via browser test:
1. Navigated to the `Sessions` tab.
2. Searched for a query with no matches.
3. Verified the empty state card correctly echoed the search term and rendered the hint details in high-contrast gray.