### PR TITLE
feat: highlight active nav item with aria-current and background tint

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -60,11 +60,17 @@ const PAGE_TITLES = {
 function activatePage(pageName) {
   if (!VALID_PAGES.has(pageName)) pageName = "home";
   document.title = PAGE_TITLES[pageName] || "Copilot Lens";
-  document.querySelectorAll(".nav-btn").forEach((b) => b.classList.remove("active"));
+  document.querySelectorAll(".nav-btn").forEach((b) => {
+    b.classList.remove("active");
+    b.removeAttribute("aria-current");
+  });
   document.querySelectorAll(".page").forEach((p) => p.classList.remove("active"));
   const btn = document.querySelector(`.nav-btn[data-page="${pageName}"]`);
   const page = document.getElementById(pageName + "Page");
-  if (btn) btn.classList.add("active");
+  if (btn) {
+    btn.classList.add("active");
+    btn.setAttribute("aria-current", "page");
+  }
   if (page) page.classList.add("active");
   if (pageName === "home") loadHome();
   if (pageName === "sessions") loadSessions();

--- a/public/style.css
+++ b/public/style.css
@@ -82,7 +82,11 @@ nav { display: flex; gap: 4px; flex: 1; }
 }
 
 .nav-btn:hover { color: var(--text); }
-.nav-btn.active { color: var(--text); border-bottom-color: var(--accent); }
+.nav-btn.active {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+}
 
 .refresh-btn {
   padding: 6px 14px;


### PR DESCRIPTION
## Summary

Closes #109 — Highlights the active navigation item in the header with a subtle background tint and adds the `aria-current="page"` attribute for accessibility.

## Visual Comparison (Before & After)

| Before (Default) | After (Highlighted Nav) |
|---|---|
| <img src="https://github.com/user-attachments/assets/420a26b4-b8d8-4957-ad78-b914f3c76af3" width="600" /> | <img src="https://github.com/user-attachments/assets/7f4ba037-a5cd-42e5-b522-22b62eadcdbe" width="600" /> |

---

## What Changed

### `public/app.js`
- Updated `activatePage()` to toggle the `aria-current="page"` attribute on the active nav button while removing it from inactive ones.

### `public/style.css`
- Enhanced the `.nav-btn.active` styling by adding a subtle background tint highlight:
  `background: color-mix(in srgb, var(--accent) 10%, transparent);`

## Verification Results

Verified the changes via browser test:
1. Checked that navigating between pages correctly adds `aria-current="page"` to the active tab button.
2. Verified that the active nav button displays a nice background tint and bottom accent border to show user focus.