### PR TITLE
feat: add digest.ts with date boundary tests (25 cases)

### DIFF
--- a/src/__tests__/digest.test.ts
+++ b/src/__tests__/digest.test.ts
@@ -1,0 +1,325 @@
+import { describe, it, expect } from "vitest";
+import { getWeekRange, getMonthRange, getDigest } from "../digest";
+
+/* ------------------------------------------------------------------ */
+/*  Helper: build a minimal session stub                               */
+/* ------------------------------------------------------------------ */
+
+function session(createdAt: string) {
+  return { createdAt, status: "completed" as const };
+}
+
+/* ================================================================== */
+/*  getWeekRange                                                       */
+/* ================================================================== */
+
+describe("getWeekRange", () => {
+  it("start is Monday 00:00:00.000 for a mid-week date", () => {
+    // 2026-06-10 is a Wednesday
+    const { start } = getWeekRange(new Date(2026, 5, 10), 0);
+    expect(start.getDay()).toBe(1); // Monday
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    expect(start.getSeconds()).toBe(0);
+    expect(start.getMilliseconds()).toBe(0);
+    expect(start.getDate()).toBe(8); // Mon Jun 8
+  });
+
+  it("end is Sunday 23:59:59.999", () => {
+    const { end } = getWeekRange(new Date(2026, 5, 10), 0);
+    expect(end.getDay()).toBe(0); // Sunday
+    expect(end.getHours()).toBe(23);
+    expect(end.getMinutes()).toBe(59);
+    expect(end.getSeconds()).toBe(59);
+    expect(end.getMilliseconds()).toBe(999);
+    expect(end.getDate()).toBe(14); // Sun Jun 14
+  });
+
+  it("works when now is already Monday", () => {
+    // 2026-06-08 is a Monday
+    const { start, end } = getWeekRange(new Date(2026, 5, 8), 0);
+    expect(start.getDate()).toBe(8);
+    expect(end.getDate()).toBe(14);
+  });
+
+  it("works when now is Sunday", () => {
+    // 2026-06-14 is a Sunday
+    const { start, end } = getWeekRange(new Date(2026, 5, 14), 0);
+    expect(start.getDay()).toBe(1);
+    expect(start.getDate()).toBe(8);
+    expect(end.getDay()).toBe(0);
+    expect(end.getDate()).toBe(14);
+  });
+
+  it("offset=-1 returns the full prior week", () => {
+    // now = Wed Jun 10 2026 → current week = Jun 8–14
+    // last week = Jun 1–7
+    const { start, end } = getWeekRange(new Date(2026, 5, 10), -1);
+    expect(start.getDate()).toBe(1);
+    expect(start.getMonth()).toBe(5); // June
+    expect(end.getDate()).toBe(7);
+    expect(end.getMonth()).toBe(5);
+  });
+
+  it("handles year-crossing boundary (Jan date, week starts in Dec)", () => {
+    // 2026-01-02 is a Friday → current week = Mon Dec 29 2025 – Sun Jan 4 2026
+    const { start, end } = getWeekRange(new Date(2026, 0, 2), 0);
+    expect(start.getFullYear()).toBe(2025);
+    expect(start.getMonth()).toBe(11); // December
+    expect(start.getDate()).toBe(29);
+    expect(end.getFullYear()).toBe(2026);
+    expect(end.getMonth()).toBe(0); // January
+    expect(end.getDate()).toBe(4);
+  });
+
+  it("handles month-crossing boundary (week spans Feb→Mar)", () => {
+    // 2026-03-01 is a Sunday → current week = Mon Feb 23 – Sun Mar 1
+    const { start, end } = getWeekRange(new Date(2026, 2, 1), 0);
+    expect(start.getMonth()).toBe(1); // February
+    expect(start.getDate()).toBe(23);
+    expect(end.getMonth()).toBe(2); // March
+    expect(end.getDate()).toBe(1);
+  });
+});
+
+/* ================================================================== */
+/*  getMonthRange                                                      */
+/* ================================================================== */
+
+describe("getMonthRange", () => {
+  it("start is 1st of the month at 00:00:00.000", () => {
+    const { start } = getMonthRange(new Date(2026, 5, 15), 0);
+    expect(start.getDate()).toBe(1);
+    expect(start.getMonth()).toBe(5);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+    expect(start.getSeconds()).toBe(0);
+    expect(start.getMilliseconds()).toBe(0);
+  });
+
+  it("end is last day of the month at 23:59:59.999", () => {
+    // June has 30 days
+    const { end } = getMonthRange(new Date(2026, 5, 15), 0);
+    expect(end.getDate()).toBe(30);
+    expect(end.getMonth()).toBe(5);
+    expect(end.getHours()).toBe(23);
+    expect(end.getMinutes()).toBe(59);
+    expect(end.getSeconds()).toBe(59);
+    expect(end.getMilliseconds()).toBe(999);
+  });
+
+  it("February in a non-leap year has 28 days", () => {
+    // 2026 is NOT a leap year
+    const { end } = getMonthRange(new Date(2026, 1, 10), 0);
+    expect(end.getDate()).toBe(28);
+    expect(end.getMonth()).toBe(1);
+  });
+
+  it("February in a leap year has 29 days", () => {
+    // 2028 IS a leap year
+    const { end } = getMonthRange(new Date(2028, 1, 10), 0);
+    expect(end.getDate()).toBe(29);
+    expect(end.getMonth()).toBe(1);
+  });
+
+  it("month with 31 days ends on 31st", () => {
+    // January has 31 days
+    const { end } = getMonthRange(new Date(2026, 0, 15), 0);
+    expect(end.getDate()).toBe(31);
+    expect(end.getMonth()).toBe(0);
+  });
+});
+
+/* ================================================================== */
+/*  getDigest — aggregation                                            */
+/* ================================================================== */
+
+describe("getDigest — aggregation", () => {
+  // Fixed reference: Wednesday 2026-06-10T12:00:00
+  // Current week = Mon Jun 8 – Sun Jun 14
+  const NOW = new Date(2026, 5, 10, 12, 0, 0);
+
+  it("counts sessions in current week correctly", () => {
+    const sessions = [
+      session("2026-06-08T10:00:00"), // Mon – in range
+      session("2026-06-10T08:30:00"), // Wed – in range
+      session("2026-06-14T23:00:00"), // Sun – in range
+      session("2026-06-07T23:59:59"), // last Sun – out
+      session("2026-06-15T00:00:00"), // next Mon – out
+    ];
+    const digest = getDigest(sessions, NOW);
+    expect(digest.currentWeek.sessions).toBe(3);
+  });
+
+  it("sums totalDuration and computes avgDuration", () => {
+    const sessions = [
+      session("2026-06-09T10:00:00"), // Tue
+      session("2026-06-11T14:00:00"), // Thu
+    ];
+    const durations = new Map([
+      ["2026-06-09T10:00:00", 60000],  // 1 min
+      ["2026-06-11T14:00:00", 120000], // 2 min
+    ]);
+    const digest = getDigest(sessions, NOW, durations);
+    expect(digest.currentWeek.totalDuration).toBe(180000);
+    expect(digest.currentWeek.avgDuration).toBe(90000);
+  });
+
+  it("session exactly on Monday 00:00:00.000 is included", () => {
+    // Create a session at the exact boundary start
+    const sessions = [session("2026-06-08T00:00:00.000")];
+    const digest = getDigest(sessions, NOW);
+    expect(digest.currentWeek.sessions).toBe(1);
+  });
+
+  it("session 1ms before range start is excluded", () => {
+    // Sunday Jun 7 23:59:59.999 — belongs to last week
+    const sessions = [session("2026-06-07T23:59:59.999")];
+    const digest = getDigest(sessions, NOW);
+    expect(digest.currentWeek.sessions).toBe(0);
+    expect(digest.lastWeek.sessions).toBe(1);
+  });
+});
+
+/* ================================================================== */
+/*  getDigest — delta calculations                                     */
+/* ================================================================== */
+
+describe("getDigest — delta calculations", () => {
+  // Current week = Mon Jun 8 – Sun Jun 14
+  // Last week    = Mon Jun 1 – Sun Jun 7
+  const NOW = new Date(2026, 5, 10, 12, 0, 0);
+
+  it("positive delta: 6 this week vs 5 last week = +20%", () => {
+    const sessions = [
+      // Last week (5 sessions)
+      session("2026-06-01T10:00:00"),
+      session("2026-06-02T10:00:00"),
+      session("2026-06-03T10:00:00"),
+      session("2026-06-04T10:00:00"),
+      session("2026-06-05T10:00:00"),
+      // This week (6 sessions)
+      session("2026-06-08T10:00:00"),
+      session("2026-06-09T10:00:00"),
+      session("2026-06-10T10:00:00"),
+      session("2026-06-11T10:00:00"),
+      session("2026-06-12T10:00:00"),
+      session("2026-06-13T10:00:00"),
+    ];
+    const digest = getDigest(sessions, NOW);
+    expect(digest.currentWeek.sessions).toBe(6);
+    expect(digest.lastWeek.sessions).toBe(5);
+    expect(digest.deltaSessionsPct).toBeCloseTo(20);
+  });
+
+  it("negative delta: 2 this week vs 4 last week = -50%", () => {
+    const sessions = [
+      // Last week (4)
+      session("2026-06-01T10:00:00"),
+      session("2026-06-02T10:00:00"),
+      session("2026-06-03T10:00:00"),
+      session("2026-06-04T10:00:00"),
+      // This week (2)
+      session("2026-06-08T10:00:00"),
+      session("2026-06-09T10:00:00"),
+    ];
+    const digest = getDigest(sessions, NOW);
+    expect(digest.deltaSessionsPct).toBeCloseTo(-50);
+  });
+
+  it("zero last week → delta is null (avoids division by zero)", () => {
+    const sessions = [
+      // Only this week
+      session("2026-06-08T10:00:00"),
+    ];
+    const digest = getDigest(sessions, NOW);
+    expect(digest.deltaSessionsPct).toBeNull();
+    expect(digest.deltaDurationPct).toBeNull();
+  });
+
+  it("identical periods → delta is 0%", () => {
+    const sessions = [
+      // Last week (3)
+      session("2026-06-01T10:00:00"),
+      session("2026-06-02T10:00:00"),
+      session("2026-06-03T10:00:00"),
+      // This week (3)
+      session("2026-06-08T10:00:00"),
+      session("2026-06-09T10:00:00"),
+      session("2026-06-10T10:00:00"),
+    ];
+    const digest = getDigest(sessions, NOW);
+    expect(digest.deltaSessionsPct).toBeCloseTo(0);
+  });
+});
+
+/* ================================================================== */
+/*  getDigest — empty / edge inputs                                    */
+/* ================================================================== */
+
+describe("getDigest — empty/edge inputs", () => {
+  const NOW = new Date(2026, 5, 10, 12, 0, 0);
+
+  it("empty session array returns zeroed stats", () => {
+    const digest = getDigest([], NOW);
+    expect(digest.currentWeek.sessions).toBe(0);
+    expect(digest.currentWeek.totalDuration).toBe(0);
+    expect(digest.currentWeek.avgDuration).toBe(0);
+    expect(digest.lastWeek.sessions).toBe(0);
+    expect(digest.currentMonth.sessions).toBe(0);
+    expect(digest.deltaSessionsPct).toBeNull();
+    expect(digest.deltaDurationPct).toBeNull();
+  });
+
+  it("all sessions outside any range returns 0 for every period", () => {
+    const sessions = [
+      session("2025-01-01T10:00:00"), // way in the past
+      session("2027-12-31T10:00:00"), // way in the future
+    ];
+    const digest = getDigest(sessions, NOW);
+    expect(digest.currentWeek.sessions).toBe(0);
+    expect(digest.lastWeek.sessions).toBe(0);
+    expect(digest.currentMonth.sessions).toBe(0);
+  });
+
+  it("sessions with missing createdAt are gracefully skipped", () => {
+    const sessions = [
+      { createdAt: "", status: "completed" as const },
+      { createdAt: "not-a-date", status: "completed" as const },
+      session("2026-06-09T10:00:00"), // valid — in current week
+    ];
+    const digest = getDigest(sessions, NOW);
+    expect(digest.currentWeek.sessions).toBe(1);
+  });
+});
+
+/* ================================================================== */
+/*  getDigest — month aggregation                                      */
+/* ================================================================== */
+
+describe("getDigest — month aggregation", () => {
+  // Fixed reference: Wednesday 2026-06-10
+  // Current month = Jun 1 – Jun 30
+  const NOW = new Date(2026, 5, 10, 12, 0, 0);
+
+  it("counts sessions in current month correctly", () => {
+    const sessions = [
+      session("2026-06-01T00:00:00"), // in
+      session("2026-06-15T12:00:00"), // in
+      session("2026-06-30T23:59:59"), // in
+      session("2026-05-31T23:59:59"), // out (May)
+      session("2026-07-01T00:00:00"), // out (July)
+    ];
+    const digest = getDigest(sessions, NOW);
+    expect(digest.currentMonth.sessions).toBe(3);
+  });
+
+  it("month range doesn't leak into adjacent months", () => {
+    const sessions = [
+      session("2026-05-31T23:59:59.999"), // last ms of May — out
+      session("2026-07-01T00:00:00.000"), // first ms of July — out
+    ];
+    const digest = getDigest(sessions, NOW);
+    expect(digest.currentMonth.sessions).toBe(0);
+  });
+});

--- a/src/digest.ts
+++ b/src/digest.ts
@@ -1,0 +1,151 @@
+import type { SessionMeta } from "./sessions";
+
+/* ------------------------------------------------------------------ */
+/*  Date-range helpers                                                 */
+/* ------------------------------------------------------------------ */
+
+export interface DateRange {
+  start: Date;
+  end: Date;
+}
+
+/**
+ * Returns the Monday-based ISO week range for a given reference date.
+ *
+ * @param now   - The reference point (any Date).
+ * @param offset - 0 = current week, -1 = last week, etc.
+ * @returns `{ start, end }` where start is Monday 00:00:00.000 and
+ *          end is Sunday 23:59:59.999 of the target week.
+ */
+export function getWeekRange(now: Date, offset = 0): DateRange {
+  const d = new Date(now);
+
+  // day-of-week: JS uses 0=Sun, 1=Mon … 6=Sat
+  // Convert to ISO convention: Mon=0, Tue=1 … Sun=6
+  const jsDay = d.getDay();
+  const isoDay = jsDay === 0 ? 6 : jsDay - 1; // Mon=0 … Sun=6
+
+  // Rewind to Monday of the current week
+  const monday = new Date(d);
+  monday.setDate(d.getDate() - isoDay + offset * 7);
+  monday.setHours(0, 0, 0, 0);
+
+  // Sunday = Monday + 6 days, at 23:59:59.999
+  const sunday = new Date(monday);
+  sunday.setDate(monday.getDate() + 6);
+  sunday.setHours(23, 59, 59, 999);
+
+  return { start: monday, end: sunday };
+}
+
+/**
+ * Returns the calendar-month range for a given reference date.
+ *
+ * @param now   - The reference point (any Date).
+ * @param offset - 0 = current month, -1 = last month, etc.
+ * @returns `{ start, end }` where start is the 1st at 00:00:00.000 and
+ *          end is the last day at 23:59:59.999.
+ */
+export function getMonthRange(now: Date, offset = 0): DateRange {
+  const year = now.getFullYear();
+  const month = now.getMonth() + offset;
+
+  const start = new Date(year, month, 1, 0, 0, 0, 0);
+
+  // Day 0 of the *next* month gives us the last day of *this* month
+  const end = new Date(year, month + 1, 0, 23, 59, 59, 999);
+
+  return { start, end };
+}
+
+/* ------------------------------------------------------------------ */
+/*  Digest aggregation                                                 */
+/* ------------------------------------------------------------------ */
+
+export interface PeriodStats {
+  sessions: number;
+  totalDuration: number;
+  avgDuration: number;
+}
+
+export interface DigestResult {
+  currentWeek: PeriodStats;
+  lastWeek: PeriodStats;
+  currentMonth: PeriodStats;
+  /** Percentage change in session count: current week vs last week.
+   *  `null` when lastWeek.sessions === 0 (avoid ÷0). */
+  deltaSessionsPct: number | null;
+  /** Percentage change in total duration: current week vs last week.
+   *  `null` when lastWeek.totalDuration === 0 (avoid ÷0). */
+  deltaDurationPct: number | null;
+}
+
+/** Filter sessions that fall within a date range by `createdAt`. */
+function sessionsInRange(
+  sessions: Pick<SessionMeta, "createdAt" | "status">[],
+  range: DateRange,
+): Pick<SessionMeta, "createdAt" | "status">[] {
+  return sessions.filter((s) => {
+    if (!s.createdAt) return false;
+    const t = new Date(s.createdAt).getTime();
+    if (Number.isNaN(t)) return false;
+    return t >= range.start.getTime() && t <= range.end.getTime();
+  });
+}
+
+/** Compute aggregate stats for a set of sessions. */
+function aggregateStats(
+  sessions: Pick<SessionMeta, "createdAt" | "status">[],
+  durations: Map<string, number>,
+): PeriodStats {
+  let totalDuration = 0;
+  for (const s of sessions) {
+    totalDuration += durations.get(s.createdAt) ?? 0;
+  }
+  return {
+    sessions: sessions.length,
+    totalDuration,
+    avgDuration: sessions.length > 0 ? totalDuration / sessions.length : 0,
+  };
+}
+
+/** Compute percentage change.  Returns `null` when base is 0. */
+function pctChange(current: number, previous: number): number | null {
+  if (previous === 0) return null;
+  return ((current - previous) / previous) * 100;
+}
+
+/**
+ * Build a weekly / monthly digest from a flat list of sessions.
+ *
+ * @param sessions  - Array of session metadata objects (only `createdAt` is required).
+ * @param now       - Reference date (defaults to `new Date()`).  Accept a param so
+ *                    tests can inject a deterministic clock.
+ * @param durations - Optional map of createdAt → duration (ms).  When omitted,
+ *                    duration is treated as 0 for every session.
+ */
+export function getDigest(
+  sessions: Pick<SessionMeta, "createdAt" | "status">[],
+  now: Date = new Date(),
+  durations: Map<string, number> = new Map(),
+): DigestResult {
+  const cwRange = getWeekRange(now, 0);
+  const lwRange = getWeekRange(now, -1);
+  const cmRange = getMonthRange(now, 0);
+
+  const cwSessions = sessionsInRange(sessions, cwRange);
+  const lwSessions = sessionsInRange(sessions, lwRange);
+  const cmSessions = sessionsInRange(sessions, cmRange);
+
+  const currentWeek = aggregateStats(cwSessions, durations);
+  const lastWeek = aggregateStats(lwSessions, durations);
+  const currentMonth = aggregateStats(cmSessions, durations);
+
+  return {
+    currentWeek,
+    lastWeek,
+    currentMonth,
+    deltaSessionsPct: pctChange(currentWeek.sessions, lastWeek.sessions),
+    deltaDurationPct: pctChange(currentWeek.totalDuration, lastWeek.totalDuration),
+  };
+}

--- a/src/digest.ts
+++ b/src/digest.ts
@@ -82,9 +82,9 @@ export interface DigestResult {
 
 /** Filter sessions that fall within a date range by `createdAt`. */
 function sessionsInRange(
-  sessions: Pick<SessionMeta, "createdAt" | "status">[],
+  sessions: Pick<SessionMeta, "createdAt">[],
   range: DateRange,
-): Pick<SessionMeta, "createdAt" | "status">[] {
+): Pick<SessionMeta, "createdAt">[] {
   return sessions.filter((s) => {
     if (!s.createdAt) return false;
     const t = new Date(s.createdAt).getTime();
@@ -95,7 +95,7 @@ function sessionsInRange(
 
 /** Compute aggregate stats for a set of sessions. */
 function aggregateStats(
-  sessions: Pick<SessionMeta, "createdAt" | "status">[],
+  sessions: Pick<SessionMeta, "createdAt">[],
   durations: Map<string, number>,
 ): PeriodStats {
   let totalDuration = 0;
@@ -125,7 +125,7 @@ function pctChange(current: number, previous: number): number | null {
  *                    duration is treated as 0 for every session.
  */
 export function getDigest(
-  sessions: Pick<SessionMeta, "createdAt" | "status">[],
+  sessions: Pick<SessionMeta, "createdAt">[],
   now: Date = new Date(),
   durations: Map<string, number> = new Map(),
 ): DigestResult {


### PR DESCRIPTION
## Summary

Closes #115 — Adds `src/digest.ts` with date-range aggregation logic and `src/__tests__/digest.test.ts` with 25 rigorous Vitest tests covering all date boundary and aggregation scenarios.

## What Changed

### `src/digest.ts` (NEW)
- **`getWeekRange(now, offset)`** — Returns Monday 00:00:00.000 → Sunday 23:59:59.999 for ISO weeks
- **`getMonthRange(now, offset)`** — Returns 1st → last day of calendar month (handles 28/29/30/31)
- **`getDigest(sessions, now?, durations?)`** — Aggregates sessions into current/last week and current month; computes delta percentages with ÷0 guard

### `src/__tests__/digest.test.ts` (NEW)
25 test cases across 6 describe blocks:

| Block | # | Coverage |
|-------|---|----------|
| `getWeekRange` | 7 | Mon/Sun boundaries, Mon/Sun as input, last week offset, year-crossing (Dec→Jan), month-crossing (Feb→Mar) |
| `getMonthRange` | 5 | Start/end boundaries, Feb non-leap (28d), Feb leap (29d), 31-day months |
| `getDigest — aggregation` | 4 | Session counting, duration math, exact boundary inclusion, 1ms exclusion |
| `getDigest — delta calculations` | 4 | Positive (+20%), negative (−50%), zero-division guard (`null`), identical (0%) |
| `getDigest — empty/edge inputs` | 3 | Empty array, all out-of-range, invalid/missing `createdAt` |
| `getDigest — month aggregation` | 2 | Correct monthly count, no leakage into adjacent months |

## Test Results

```
✓ src/__tests__/digest.test.ts (25 tests) 11ms
Tests  25 passed (25)
```

## Design Decisions

- All functions accept an injectable `now` parameter so tests are fully deterministic (no timezone flakiness)
- Delta returns `null` instead of `Infinity` when the prior period has zero sessions (explicit ÷0 guard)
- `sessionsInRange` silently skips entries with empty or unparseable `createdAt` strings