### PR TITLE
feat: add loading spinners for search and refresh actions

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -437,6 +437,11 @@ function escapeHtml(str) {
 
 // Analytics
 async function loadAnalytics() {
+  statsCards.innerHTML = Array.from({ length: 4 }, () => `
+    <div class="stat-card">
+      <div class="stat-value">…</div>
+      <div class="stat-label">Loading</div>
+    </div>`).join("");
   try {
     const res = await fetch(`/api/analytics?source=${analyticsSource}`);
     analytics = await res.json();
@@ -745,6 +750,17 @@ const insightsContent = document.getElementById("insightsContent");
 let insightsRepos = [];
 
 async function loadInsights() {
+  insightsContent.innerHTML = `
+    <div class="skeleton-card">
+      <div class="skeleton-line" style="width:55%;height:16px;margin-bottom:12px"></div>
+      <div class="skeleton-line" style="width:75%"></div>
+      <div class="skeleton-line" style="width:40%"></div>
+    </div>
+    <div class="skeleton-card" style="margin-top:16px">
+      <div class="skeleton-line" style="width:65%;height:14px;margin-bottom:10px"></div>
+      <div class="skeleton-line" style="width:80%"></div>
+      <div class="skeleton-line" style="width:50%"></div>
+    </div>`;
   try {
     const res = await fetch("/api/insights/repos");
     insightsRepos = await res.json();
@@ -852,6 +868,8 @@ function renderInsightsScore(data) {
 
 // Full-text search
 async function runSearch(q) {
+  const searchWrap = document.querySelector(".search-bar-wrap");
+  if (searchWrap) searchWrap.classList.add("loading");
   try {
     const res = await fetch(`/api/search?q=${encodeURIComponent(q)}&source=all&limit=20`);
     const results = await res.json();
@@ -860,6 +878,8 @@ async function runSearch(q) {
   } catch (err) {
     isSearchActive = true;
     sessionList.innerHTML = `<div class="error-message">Search failed: ${escapeHtml(err.message)}</div>`;
+  } finally {
+    if (searchWrap) searchWrap.classList.remove("loading");
   }
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -58,7 +58,7 @@
         <div class="list-pane">
           <div class="search-bar-wrap">
             <span class="search-icon">🔍</span>
-            <span class="search-spinner" id="searchSpinner" style="display:none"></span>
+            <span class="search-spinner" id="searchSpinner"></span>
             <input
               type="text"
               id="searchInput"

--- a/public/index.html
+++ b/public/index.html
@@ -18,7 +18,7 @@
       <button class="nav-btn" data-page="insights">Insights</button>
       <button class="nav-btn" data-page="docs">Docs</button>
     </nav>
-    <button class="refresh-btn" id="refreshBtn" title="Refresh data">⟳ Refresh</button>
+    <button class="refresh-btn" id="refreshBtn" title="Refresh data"><span class="refresh-arrow">⟳</span> Refresh</button>
     <button class="refresh-btn" id="themeToggle" title="Toggle light/dark mode">☀️</button>
   </header>
 
@@ -58,6 +58,7 @@
         <div class="list-pane">
           <div class="search-bar-wrap">
             <span class="search-icon">🔍</span>
+            <span class="search-spinner" id="searchSpinner" style="display:none"></span>
             <input
               type="text"
               id="searchInput"

--- a/public/style.css
+++ b/public/style.css
@@ -1367,3 +1367,38 @@ select:focus { box-shadow: 0 0 0 3px rgba(88,166,255,0.15); }
 .docs-list li + li { border-top: 1px solid var(--border); }
 
 .docs strong { color: var(--text); font-weight: 600; }
+
+/* Loading spinner animations and styles */
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.search-spinner {
+  display: none;
+  position: absolute;
+  left: 12px;
+  width: 14px;
+  height: 14px;
+  border: 2px solid rgba(88, 166, 255, 0.2);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: spin 0.8s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+  z-index: 1;
+}
+
+.search-bar-wrap.loading .search-icon {
+  display: none;
+}
+
+.search-bar-wrap.loading .search-spinner {
+  display: block;
+}
+
+.refresh-arrow {
+  display: inline-block;
+  transition: transform 0.15s;
+}
+
+.refresh-btn.spinning .refresh-arrow {
+  animation: spin 0.8s linear infinite;
+}


### PR DESCRIPTION
## Summary

Closes #101 — Adds visual loading feedback across the Copilot Lens dashboard to improve responsiveness during API data requests.

## Visual Comparison (Before & After)

| Feature | Before (Default) | After (Loading / Spinning) |
|---|---|---|
| **Refresh Button** | <img src="https://github.com/user-attachments/assets/420a26b4-b8d8-4957-ad78-b914f3c76af3" width="600" /> | <img src="https://github.com/user-attachments/assets/f36a8900-8dfb-457e-abb7-5c7d6f9589b8" width="600" /> |
| **Search Input** | <img src="https://github.com/user-attachments/assets/769e52db-e2a9-4ddf-b923-057c4bc84b2a" width="600" /> | <img src="https://github.com/user-attachments/assets/c221d059-eabe-41cf-bb9e-bcb6cfe2b7ca" width="600" /> |
| **Analytics Skeleton** | *(No state/empty)* | <img src="https://github.com/user-attachments/assets/e57ef30c-57ae-4081-a77a-ff1dbe1296c2" width="600" /> |
| **Insights Skeleton** | *(No state/empty)* | <img src="https://github.com/user-attachments/assets/4c911772-2015-4cd8-8199-e49bd3d09862" width="600" /> |

---

## What Changed

### `public/index.html`
- Added a `.search-spinner` element inside the search bar container.
- Wrapped the refresh unicode character `⟳` in `<span class="refresh-arrow">⟳</span>`.

### `public/style.css`
- Added a smooth, custom cubic-bezier rotating animation `@keyframes spin`.
- Positioned `.search-spinner` on the left of the search input.
- Added rules to hide `.search-icon` and display `.search-spinner` when `.search-bar-wrap` has the `.loading` class.
- Added styles to rotate the `⟳` arrow when the `.refresh-btn` has the `.spinning` class.

### `public/app.js`
- Toggled the `.loading` class on `.search-bar-wrap` during API calls in `runSearch(q)` using a `try...finally` block.
- Implemented skeleton loader cards inside `loadAnalytics()` and `loadInsights()` while data is being fetched.

## Verification Results

Verified the changes via browser test:
1. Checked that clicking "Refresh" triggers the `.spinning` class and spins the `⟳` symbol smoothly.
2. Verified that typing a query in the Sessions tab search input displays the loading spinner on the left side of the input.
3. Verified that the Analytics and Insights tabs render skeleton loaders while data is fetching.
