### PR TITLE
fix: mock USERPROFILE on Windows to fix test isolation issues

### DIFF
--- a/src/__tests__/claude-code-sessions.test.ts
+++ b/src/__tests__/claude-code-sessions.test.ts
@@ -95,6 +95,8 @@ describe("listClaudeCodeSessions / getClaudeCodeSession / isClaudeCodeSession", 
   let tmpDir: string;
   let projectsDir: string;
   let projectDir: string;
+  let origHome: string | undefined;
+  let origUserProfile: string | undefined;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-lens-test-"));
@@ -103,12 +105,24 @@ describe("listClaudeCodeSessions / getClaudeCodeSession / isClaudeCodeSession", 
     fs.mkdirSync(projectDir, { recursive: true });
 
     // Override home dir so getClaudeCodeProjectsDir() points to tmpDir
+    origHome = process.env.HOME;
+    origUserProfile = process.env.USERPROFILE;
     process.env.HOME = tmpDir;
+    process.env.USERPROFILE = tmpDir;
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
-    delete process.env.HOME;
+    if (origHome !== undefined) {
+      process.env.HOME = origHome;
+    } else {
+      delete process.env.HOME;
+    }
+    if (origUserProfile !== undefined) {
+      process.env.USERPROFILE = origUserProfile;
+    } else {
+      delete process.env.USERPROFILE;
+    }
   });
 
   function writeSession(sessionId: string, lines: string[]): void {
@@ -260,18 +274,32 @@ describe("listClaudeCodeSessions / getClaudeCodeSession / isClaudeCodeSession", 
 describe("getClaudeCodeAnalytics", () => {
   let tmpDir: string;
   let projectDir: string;
+  let origHome: string | undefined;
+  let origUserProfile: string | undefined;
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "claude-lens-analytics-"));
     projectDir = path.join(tmpDir, ".claude", "projects", "-Users-test-proj");
     fs.mkdirSync(projectDir, { recursive: true });
+    origHome = process.env.HOME;
+    origUserProfile = process.env.USERPROFILE;
     process.env.HOME = tmpDir;
+    process.env.USERPROFILE = tmpDir;
     clearCache();
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
-    delete process.env.HOME;
+    if (origHome !== undefined) {
+      process.env.HOME = origHome;
+    } else {
+      delete process.env.HOME;
+    }
+    if (origUserProfile !== undefined) {
+      process.env.USERPROFILE = origUserProfile;
+    } else {
+      delete process.env.USERPROFILE;
+    }
     clearCache();
   });
 

--- a/src/__tests__/vscode-sessions.test.ts
+++ b/src/__tests__/vscode-sessions.test.ts
@@ -442,7 +442,7 @@ describe("normalizeVSCodeToolName", () => {
 
 describe("scanVSCodeMcpConfig", () => {
   let tmpDir: string;
-  let origHome: string;
+  let origHome: string | undefined;
   let origUserProfile: string | undefined;
   let origAppData: string | undefined;
 
@@ -459,7 +459,7 @@ describe("scanVSCodeMcpConfig", () => {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-lens-mcp-test-"));
-    origHome = process.env.HOME || "";
+    origHome = process.env.HOME;
     origUserProfile = process.env.USERPROFILE;
     origAppData = process.env.APPDATA;
     // Override HOME, USERPROFILE, and APPDATA so scanVSCodeMcpConfig looks in our temp dir
@@ -472,7 +472,11 @@ describe("scanVSCodeMcpConfig", () => {
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
-    process.env.HOME = origHome;
+    if (origHome !== undefined) {
+      process.env.HOME = origHome;
+    } else {
+      delete process.env.HOME;
+    }
     if (origUserProfile !== undefined) {
       process.env.USERPROFILE = origUserProfile;
     } else {

--- a/src/__tests__/vscode-sessions.test.ts
+++ b/src/__tests__/vscode-sessions.test.ts
@@ -443,6 +443,7 @@ describe("normalizeVSCodeToolName", () => {
 describe("scanVSCodeMcpConfig", () => {
   let tmpDir: string;
   let origHome: string;
+  let origUserProfile: string | undefined;
   let origAppData: string | undefined;
 
   // Helper to create platform-appropriate VS Code data directory
@@ -459,9 +460,11 @@ describe("scanVSCodeMcpConfig", () => {
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "copilot-lens-mcp-test-"));
     origHome = process.env.HOME || "";
+    origUserProfile = process.env.USERPROFILE;
     origAppData = process.env.APPDATA;
-    // Override HOME and APPDATA so scanVSCodeMcpConfig looks in our temp dir
+    // Override HOME, USERPROFILE, and APPDATA so scanVSCodeMcpConfig looks in our temp dir
     process.env.HOME = tmpDir;
+    process.env.USERPROFILE = tmpDir;
     if (process.platform === "win32") {
       process.env.APPDATA = path.join(tmpDir, "AppData", "Roaming");
     }
@@ -470,6 +473,11 @@ describe("scanVSCodeMcpConfig", () => {
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
     process.env.HOME = origHome;
+    if (origUserProfile !== undefined) {
+      process.env.USERPROFILE = origUserProfile;
+    } else {
+      delete process.env.USERPROFILE;
+    }
     if (origAppData !== undefined) {
       process.env.APPDATA = origAppData;
     } else {


### PR DESCRIPTION
## Summary

Closes #163 — Fixes cross-platform test isolation failures on Windows caused by `os.homedir()` ignoring `process.env.HOME` overrides and instead reading `process.env.USERPROFILE`.

## Root Cause

Node.js's `os.homedir()` resolves the home directory differently per OS:
- **macOS / Linux** — reads `process.env.HOME`
- **Windows** — reads `process.env.USERPROFILE` (falling back to `HOMEDRIVE` + `HOMEPATH`)

The test suites in `claude-code-sessions.test.ts` and `vscode-sessions.test.ts` were redirecting the home directory to a temporary test folder by overriding only `process.env.HOME`. On Windows this had no effect, so `os.homedir()` returned the developer's actual home directory. Tests that wrote session files into the temporary folder never found them when the code looked in the real home directory, causing 8 tests to fail.

## What Changed

### `src/__tests__/claude-code-sessions.test.ts`
- Added `origHome` and `origUserProfile` variables to capture the pre-test values.
- `beforeEach`: Now sets **both** `process.env.HOME` and `process.env.USERPROFILE` to `tmpDir`.
- `afterEach`: Restores (or deletes) **both** environment variables to their pre-test values, preventing state leakage between tests.
- Applied to both the `listClaudeCodeSessions / getClaudeCodeSession / isClaudeCodeSession` and `getClaudeCodeAnalytics` describe blocks.

### `src/__tests__/vscode-sessions.test.ts`
- Added `origUserProfile` variable to the `scanVSCodeMcpConfig` describe block.
- `beforeEach`: Now sets `process.env.USERPROFILE = tmpDir` alongside `process.env.HOME`.
- `afterEach`: Restores (or deletes) `USERPROFILE` correctly.

## Verification Results

All 120 tests pass on Windows:

```
Test Files  8 passed (8)
     Tests  120 passed (120)
  Duration  1.29s
```