### PR TITLE
fix: validate CLI port argument

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,7 +35,12 @@ if (args[0] === "tokens") {
     return idx !== -1 && args[idx + 1] ? args[idx + 1] : fallback;
   }
 
-  const port = parseInt(getArg("--port", "3000"), 10);
+  const portArg = getArg("--port", "3000");
+  const port = Number(portArg);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    console.error("Error: --port must be a number between 1 and 65535");
+    process.exit(1);
+  }
   const host = getArg("--host", "localhost");
   const shouldOpen = args.includes("--open");
 


### PR DESCRIPTION
## Summary
- validate `--port` as an integer before starting the dashboard
- reject non-numeric, zero/negative, and >65535 values with a clear CLI error

Closes #37.

## Validation
- `npm run build`
- `npx tsx src/cli.ts --port 0` exits 1 with the expected error
- `npx tsx src/cli.ts --port 99999` exits 1 with the expected error
- `npx tsx src/cli.ts --port abc` exits 1 with the expected error
- `git diff --check`

Note: `npm test` currently fails locally in `src/__tests__/claude-code-sessions.test.ts` because the Claude Code session fixture reads back as empty/null in this Windows environment; this PR only touches `src/cli.ts` port validation.