### PR TITLE
feat: add health check endpoint

### DIFF
--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -1,0 +1,45 @@
+import type { Server } from "node:http";
+import { describe, expect, it } from "vitest";
+import { createApp } from "../server";
+
+function startTestServer(): Promise<Server> {
+  const app = createApp();
+
+  return new Promise((resolve) => {
+    const server = app.listen(0, "127.0.0.1", () => resolve(server));
+  });
+}
+
+function closeTestServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+describe("GET /api/health", () => {
+  it("returns an OK status and version", async () => {
+    const server = await startTestServer();
+    const address = server.address();
+
+    if (!address || typeof address === "string") {
+      throw new Error("Test server did not start correctly");
+    }
+
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${address.port}/api/health`
+      );
+
+      expect(response.status).toBe(200);
+      await expect(response.json()).resolves.toEqual({
+        status: "ok",
+        version: expect.any(String),
+      });
+    } finally {
+      await closeTestServer(server);
+    }
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -46,17 +46,27 @@ export function createApp(options: AppOptions = {}) {
 
   const searchIndex = new SearchIndex();
 
-  // Serve static frontend files
-  app.use(express.static(path.join(__dirname, "..", "public")));
+  // Cache version once when the app is created (avoid per-request I/O)
+  let appVersion = process.env.npm_package_version;
+  if (!appVersion) {
+    try {
+      appVersion = (require("../package.json") as { version?: string }).version;
+    } catch {
+      appVersion = "0.0.0";
+    }
+  }
 
   // API: Health check
   app.get("/api/health", (_req, res) => {
-  res.status(200).json({
+    res.status(200).json({
       status: "ok",
-      version: process.env.npm_package_version ?? "unknown",
+      version: appVersion,
     });
   });
 
+  // Serve static frontend files
+  app.use(express.static(path.join(__dirname, "..", "public")));
+
   // API: Full-text search
   app.get("/api/search", async (req, res) => {
     try {

--- a/src/server.ts
+++ b/src/server.ts
@@ -49,6 +49,14 @@ export function createApp(options: AppOptions = {}) {
   // Serve static frontend files
   app.use(express.static(path.join(__dirname, "..", "public")));
 
+  // API: Health check
+  app.get("/api/health", (_req, res) => {
+  res.status(200).json({
+      status: "ok",
+      version: process.env.npm_package_version ?? "unknown",
+    });
+  });
+
   // API: Full-text search
   app.get("/api/search", async (req, res) => {
     try {


### PR DESCRIPTION
Closes #193

 ##
Summary
- Added a lightweight `GET /api/health` endpoint.
- Returns HTTP 200 with an `ok` status and version string.
- Added endpoint coverage with Vitest.

## Testing
- Verified `GET /api/health` locally.
- Ran `npm test`.

<img width="1897" height="954" alt="Screenshot 2026-06-23 014754" src="https://github.com/user-attachments/assets/8cff1dfb-d6ba-427c-9ed7-2ac6297ef79e" />
